### PR TITLE
Add TabBar and BaseViewController

### DIFF
--- a/Facebook/Facebook.xcodeproj/project.pbxproj
+++ b/Facebook/Facebook.xcodeproj/project.pbxproj
@@ -19,7 +19,7 @@
 		B897A922274E612B00FB67D3 /* NewsfeedTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B897A921274E612B00FB67D3 /* NewsfeedTabView.swift */; };
 		B897A924274E61A900FB67D3 /* ProfileTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B897A923274E61A900FB67D3 /* ProfileTabView.swift */; };
 		B897A926274E61D800FB67D3 /* NotificationTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B897A925274E61D800FB67D3 /* NotificationTabView.swift */; };
-		B897A928274E69CF00FB67D3 /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B897A927274E69CF00FB67D3 /* BaseViewController.swift */; };
+		B897A928274E69CF00FB67D3 /* BaseTabViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B897A927274E69CF00FB67D3 /* BaseTabViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -39,7 +39,7 @@
 		B897A921274E612B00FB67D3 /* NewsfeedTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsfeedTabView.swift; sourceTree = "<group>"; };
 		B897A923274E61A900FB67D3 /* ProfileTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileTabView.swift; sourceTree = "<group>"; };
 		B897A925274E61D800FB67D3 /* NotificationTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationTabView.swift; sourceTree = "<group>"; };
-		B897A927274E69CF00FB67D3 /* BaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseViewController.swift; sourceTree = "<group>"; };
+		B897A927274E69CF00FB67D3 /* BaseTabViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseTabViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -99,7 +99,7 @@
 			isa = PBXGroup;
 			children = (
 				B897A914274E372300FB67D3 /* RootTabBarController.swift */,
-				B897A927274E69CF00FB67D3 /* BaseViewController.swift */,
+				B897A927274E69CF00FB67D3 /* BaseTabViewController.swift */,
 				B897A91E274E389000FB67D3 /* NewsfeedTabViewController.swift */,
 				B897A918274E378300FB67D3 /* ProfileTabViewController.swift */,
 				B897A91C274E387300FB67D3 /* NotificationTabViewController.swift */,
@@ -244,7 +244,7 @@
 				B897A91F274E389000FB67D3 /* NewsfeedTabViewController.swift in Sources */,
 				B897A924274E61A900FB67D3 /* ProfileTabView.swift in Sources */,
 				B897A915274E372300FB67D3 /* RootTabBarController.swift in Sources */,
-				B897A928274E69CF00FB67D3 /* BaseViewController.swift in Sources */,
+				B897A928274E69CF00FB67D3 /* BaseTabViewController.swift in Sources */,
 				B897A919274E378300FB67D3 /* ProfileTabViewController.swift in Sources */,
 				B897A922274E612B00FB67D3 /* NewsfeedTabView.swift in Sources */,
 				B897A91D274E387300FB67D3 /* NotificationTabViewController.swift in Sources */,

--- a/Facebook/Facebook.xcodeproj/project.pbxproj
+++ b/Facebook/Facebook.xcodeproj/project.pbxproj
@@ -16,6 +16,10 @@
 		B897A919274E378300FB67D3 /* ProfileTabViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B897A918274E378300FB67D3 /* ProfileTabViewController.swift */; };
 		B897A91D274E387300FB67D3 /* NotificationTabViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B897A91C274E387300FB67D3 /* NotificationTabViewController.swift */; };
 		B897A91F274E389000FB67D3 /* NewsfeedTabViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B897A91E274E389000FB67D3 /* NewsfeedTabViewController.swift */; };
+		B897A922274E612B00FB67D3 /* NewsfeedTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B897A921274E612B00FB67D3 /* NewsfeedTabView.swift */; };
+		B897A924274E61A900FB67D3 /* ProfileTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B897A923274E61A900FB67D3 /* ProfileTabView.swift */; };
+		B897A926274E61D800FB67D3 /* NotificationTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B897A925274E61D800FB67D3 /* NotificationTabView.swift */; };
+		B897A928274E69CF00FB67D3 /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B897A927274E69CF00FB67D3 /* BaseViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -32,6 +36,10 @@
 		B897A918274E378300FB67D3 /* ProfileTabViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileTabViewController.swift; sourceTree = "<group>"; };
 		B897A91C274E387300FB67D3 /* NotificationTabViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationTabViewController.swift; sourceTree = "<group>"; };
 		B897A91E274E389000FB67D3 /* NewsfeedTabViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsfeedTabViewController.swift; sourceTree = "<group>"; };
+		B897A921274E612B00FB67D3 /* NewsfeedTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsfeedTabView.swift; sourceTree = "<group>"; };
+		B897A923274E61A900FB67D3 /* ProfileTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileTabView.swift; sourceTree = "<group>"; };
+		B897A925274E61D800FB67D3 /* NotificationTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationTabView.swift; sourceTree = "<group>"; };
+		B897A927274E69CF00FB67D3 /* BaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -52,7 +60,6 @@
 				6359F47475B70FE61F708C89 /* Pods-Facebook.debug.xcconfig */,
 				AF0AA20D3E5E391258D676CE /* Pods-Facebook.release.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -77,8 +84,7 @@
 		B897A8FC274E303600FB67D3 /* Facebook */ = {
 			isa = PBXGroup;
 			children = (
-				B897A911274E36E500FB67D3 /* Model */,
-				B897A912274E36F100FB67D3 /* View */,
+				B897A920274E611400FB67D3 /* View */,
 				B897A913274E36FC00FB67D3 /* Controller */,
 				B897A8FD274E303600FB67D3 /* AppDelegate.swift */,
 				B897A8FF274E303600FB67D3 /* SceneDelegate.swift */,
@@ -89,29 +95,26 @@
 			path = Facebook;
 			sourceTree = "<group>";
 		};
-		B897A911274E36E500FB67D3 /* Model */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Model;
-			sourceTree = "<group>";
-		};
-		B897A912274E36F100FB67D3 /* View */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = View;
-			sourceTree = "<group>";
-		};
 		B897A913274E36FC00FB67D3 /* Controller */ = {
 			isa = PBXGroup;
 			children = (
 				B897A914274E372300FB67D3 /* RootTabBarController.swift */,
+				B897A927274E69CF00FB67D3 /* BaseViewController.swift */,
 				B897A91E274E389000FB67D3 /* NewsfeedTabViewController.swift */,
 				B897A918274E378300FB67D3 /* ProfileTabViewController.swift */,
 				B897A91C274E387300FB67D3 /* NotificationTabViewController.swift */,
 			);
 			path = Controller;
+			sourceTree = "<group>";
+		};
+		B897A920274E611400FB67D3 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				B897A921274E612B00FB67D3 /* NewsfeedTabView.swift */,
+				B897A923274E61A900FB67D3 /* ProfileTabView.swift */,
+				B897A925274E61D800FB67D3 /* NotificationTabView.swift */,
+			);
+			path = View;
 			sourceTree = "<group>";
 		};
 		C012E5AC2AFFD2D68B2B2EE8 /* Frameworks */ = {
@@ -237,9 +240,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				B897A8FE274E303600FB67D3 /* AppDelegate.swift in Sources */,
+				B897A926274E61D800FB67D3 /* NotificationTabView.swift in Sources */,
 				B897A91F274E389000FB67D3 /* NewsfeedTabViewController.swift in Sources */,
+				B897A924274E61A900FB67D3 /* ProfileTabView.swift in Sources */,
 				B897A915274E372300FB67D3 /* RootTabBarController.swift in Sources */,
+				B897A928274E69CF00FB67D3 /* BaseViewController.swift in Sources */,
 				B897A919274E378300FB67D3 /* ProfileTabViewController.swift in Sources */,
+				B897A922274E612B00FB67D3 /* NewsfeedTabView.swift in Sources */,
 				B897A91D274E387300FB67D3 /* NotificationTabViewController.swift in Sources */,
 				B897A900274E303600FB67D3 /* SceneDelegate.swift in Sources */,
 			);

--- a/Facebook/Facebook/Controller/BaseTabViewController.swift
+++ b/Facebook/Facebook/Controller/BaseTabViewController.swift
@@ -1,5 +1,5 @@
 //
-//  BaseViewController.swift
+//  BaseTabViewController.swift
 //  Facebook
 //
 //  Created by 최유림 on 2021/11/24.
@@ -8,13 +8,15 @@
 import RxSwift
 import RxGesture
 
-class BaseViewController: UIViewController {
+class BaseTabViewController<View: UIView>: UIViewController {
 
     private let searchButton = UIBarButtonItem(image: UIImage(systemName: "magnifyingglass", withConfiguration: UIImage.SymbolConfiguration(weight: .semibold)), style: .plain, target: nil, action: nil)
     
     private let editButton = UIBarButtonItem(image: UIImage(systemName: "pencil", withConfiguration: UIImage.SymbolConfiguration(weight: .black)), style: .plain, target: nil, action: nil)
     
     private let disposeBag = DisposeBag()
+    
+    override func loadView() { view = View() }
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Facebook/Facebook/Controller/BaseTabViewController.swift
+++ b/Facebook/Facebook/Controller/BaseTabViewController.swift
@@ -14,14 +14,19 @@ class BaseTabViewController<View: UIView>: UIViewController {
     
     private let editButton = UIBarButtonItem(image: UIImage(systemName: "pencil", withConfiguration: UIImage.SymbolConfiguration(weight: .black)), style: .plain, target: nil, action: nil)
     
-    private let disposeBag = DisposeBag()
+    let disposeBag = DisposeBag()
     
     override func loadView() { view = View() }
+    
+    var tabView: View {
+        guard let view = view as? View else { return View() }
+        return view
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
         setNavigationBarItems()
-        bindView()
+        bindNavigationBarItems()
     }
     
     func setNavigationBarItems(withEditButton: Bool = false) {
@@ -31,7 +36,7 @@ class BaseTabViewController<View: UIView>: UIViewController {
         }
     }
     
-    private func bindView() {
+    private func bindNavigationBarItems() {
         searchButton.rx.tap.bind { _ in
             print("search button tapped")
             // searchViewController 띄우기

--- a/Facebook/Facebook/Controller/BaseViewController.swift
+++ b/Facebook/Facebook/Controller/BaseViewController.swift
@@ -1,0 +1,44 @@
+//
+//  BaseViewController.swift
+//  Facebook
+//
+//  Created by 최유림 on 2021/11/24.
+//
+
+import RxSwift
+import RxGesture
+
+class BaseViewController: UIViewController {
+
+    private let searchButton = UIBarButtonItem(image: UIImage(systemName: "magnifyingglass", withConfiguration: UIImage.SymbolConfiguration(weight: .semibold)), style: .plain, target: nil, action: nil)
+    
+    private let editButton = UIBarButtonItem(image: UIImage(systemName: "pencil", withConfiguration: UIImage.SymbolConfiguration(weight: .black)), style: .plain, target: nil, action: nil)
+    
+    private let disposeBag = DisposeBag()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setNavigationBarItems()
+        bindView()
+    }
+    
+    func setNavigationBarItems(withEditButton: Bool = false) {
+        switch withEditButton {
+        case true: self.navigationItem.rightBarButtonItems = [searchButton, editButton]
+        case false: self.navigationItem.rightBarButtonItem = searchButton
+        }
+    }
+    
+    private func bindView() {
+        searchButton.rx.tap.bind { _ in
+            print("search button tapped")
+            // searchViewController 띄우기
+        }.disposed(by: disposeBag)
+        
+        editButton.rx.tap.bind { _ in
+            print("edit button tapped")
+            // editProfileViewController 띄우기
+        }.disposed(by: disposeBag)
+    }
+
+}

--- a/Facebook/Facebook/Controller/NewsfeedTabViewController.swift
+++ b/Facebook/Facebook/Controller/NewsfeedTabViewController.swift
@@ -5,15 +5,19 @@
 //  Created by 최유림 on 2021/11/24.
 //
 
-import UIKit
+import RxSwift
+import RxGesture
 
-class NewsfeedTabViewController: UIViewController {
+class NewsfeedTabViewController<View: NewsfeedTabView>: BaseViewController {
 
+    override func loadView() { view = View() }
+    
+    private final var newsfeed: NewsfeedTabView { return view as! View }
+    
+    private let disposeBag = DisposeBag()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-
     }
-    
-
 
 }

--- a/Facebook/Facebook/Controller/NewsfeedTabViewController.swift
+++ b/Facebook/Facebook/Controller/NewsfeedTabViewController.swift
@@ -12,7 +12,12 @@ class NewsfeedTabViewController<View: NewsfeedTabView>: BaseViewController {
 
     override func loadView() { view = View() }
     
-    private final var newsfeed: NewsfeedTabView { return view as! View }
+    private final var newsfeed: NewsfeedTabView {
+        guard let view = view as? View else {
+            return NewsfeedTabView()
+        }
+        return view
+    }
     
     private let disposeBag = DisposeBag()
     

--- a/Facebook/Facebook/Controller/NewsfeedTabViewController.swift
+++ b/Facebook/Facebook/Controller/NewsfeedTabViewController.swift
@@ -5,12 +5,8 @@
 //  Created by 최유림 on 2021/11/24.
 //
 
-import RxSwift
-import RxGesture
-
 class NewsfeedTabViewController: BaseTabViewController<NewsfeedTabView> {
 
-    private let disposeBag = DisposeBag()
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Facebook/Facebook/Controller/NewsfeedTabViewController.swift
+++ b/Facebook/Facebook/Controller/NewsfeedTabViewController.swift
@@ -8,17 +8,8 @@
 import RxSwift
 import RxGesture
 
-class NewsfeedTabViewController<View: NewsfeedTabView>: BaseViewController {
+class NewsfeedTabViewController: BaseTabViewController<NewsfeedTabView> {
 
-    override func loadView() { view = View() }
-    
-    private final var newsfeed: NewsfeedTabView {
-        guard let view = view as? View else {
-            return NewsfeedTabView()
-        }
-        return view
-    }
-    
     private let disposeBag = DisposeBag()
     
     override func viewDidLoad() {

--- a/Facebook/Facebook/Controller/NotificationTabViewController.swift
+++ b/Facebook/Facebook/Controller/NotificationTabViewController.swift
@@ -5,8 +5,6 @@
 //  Created by 최유림 on 2021/11/24.
 //
 
-import UIKit
-
 class NotificationTabViewController: BaseTabViewController<NotificationTabView> {
 
     override func viewDidLoad() {

--- a/Facebook/Facebook/Controller/NotificationTabViewController.swift
+++ b/Facebook/Facebook/Controller/NotificationTabViewController.swift
@@ -11,7 +11,12 @@ class NotificationTabViewController<View: NotificationTabView>: BaseViewControll
 
     override func loadView() { view = View() }
     
-    private final var notification: NotificationTabView { return view as! View }
+    private final var notification: NotificationTabView {
+        guard let view = view as? View else {
+            return NotificationTabView()
+        }
+        return view
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Facebook/Facebook/Controller/NotificationTabViewController.swift
+++ b/Facebook/Facebook/Controller/NotificationTabViewController.swift
@@ -7,17 +7,8 @@
 
 import UIKit
 
-class NotificationTabViewController<View: NotificationTabView>: BaseViewController {
+class NotificationTabViewController: BaseTabViewController<NotificationTabView> {
 
-    override func loadView() { view = View() }
-    
-    private final var notification: NotificationTabView {
-        guard let view = view as? View else {
-            return NotificationTabView()
-        }
-        return view
-    }
-    
     override func viewDidLoad() {
         super.viewDidLoad()
 

--- a/Facebook/Facebook/Controller/NotificationTabViewController.swift
+++ b/Facebook/Facebook/Controller/NotificationTabViewController.swift
@@ -7,8 +7,12 @@
 
 import UIKit
 
-class NotificationTabViewController: UIViewController {
+class NotificationTabViewController<View: NotificationTabView>: BaseViewController {
 
+    override func loadView() { view = View() }
+    
+    private final var notification: NotificationTabView { return view as! View }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
 

--- a/Facebook/Facebook/Controller/ProfileTabViewController.swift
+++ b/Facebook/Facebook/Controller/ProfileTabViewController.swift
@@ -7,11 +7,15 @@
 
 import UIKit
 
-class ProfileTabViewController: UIViewController {
+class ProfileTabViewController<View: ProfileTabView>: BaseViewController {
 
+    override func loadView() { view = View() }
+    
+    private final var profile: ProfileTabView { return view as! View }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        super.setNavigationBarItems(withEditButton: true)
     }
     
 

--- a/Facebook/Facebook/Controller/ProfileTabViewController.swift
+++ b/Facebook/Facebook/Controller/ProfileTabViewController.swift
@@ -11,7 +11,12 @@ class ProfileTabViewController<View: ProfileTabView>: BaseViewController {
 
     override func loadView() { view = View() }
     
-    private final var profile: ProfileTabView { return view as! View }
+    private final var profile: ProfileTabView {
+        guard let view = view as? View else {
+            return ProfileTabView()
+        }
+        return view
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Facebook/Facebook/Controller/ProfileTabViewController.swift
+++ b/Facebook/Facebook/Controller/ProfileTabViewController.swift
@@ -9,13 +9,8 @@ import UIKit
 
 class ProfileTabViewController: BaseTabViewController<ProfileTabView> {
 
-
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         super.setNavigationBarItems(withEditButton: true)
     }
-    
-
-
 }

--- a/Facebook/Facebook/Controller/ProfileTabViewController.swift
+++ b/Facebook/Facebook/Controller/ProfileTabViewController.swift
@@ -7,16 +7,9 @@
 
 import UIKit
 
-class ProfileTabViewController<View: ProfileTabView>: BaseViewController {
+class ProfileTabViewController: BaseTabViewController<ProfileTabView> {
 
-    override func loadView() { view = View() }
-    
-    private final var profile: ProfileTabView {
-        guard let view = view as? View else {
-            return ProfileTabView()
-        }
-        return view
-    }
+
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Facebook/Facebook/Controller/RootTabBarController.swift
+++ b/Facebook/Facebook/Controller/RootTabBarController.swift
@@ -7,13 +7,40 @@
 
 import UIKit
 
-class RootTabBarController: UIViewController {
+class RootTabBarController: UITabBarController, UITabBarControllerDelegate {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        delegate = self
+        
+        self.tabBar.tintColor = .systemBlue
+        self.tabBar.unselectedItemTintColor = .darkGray
+        
+        self.view.backgroundColor = .white
+        self.view.tintColor = .darkGray
+        self.navigationItem.backButtonTitle = ""
     }
-    
 
+    override func viewWillAppear(_ animated: Bool) {
+        
+        let newsfeedTabViewController = UINavigationController(rootViewController: NewsfeedTabViewController())
+        let newsfeedTabViewIcon = UITabBarItem(title: "뉴스피드", image: UIImage(systemName: "house"), selectedImage: UIImage(systemName: "house.fill"))
+        newsfeedTabViewController.tabBarItem = newsfeedTabViewIcon
+        
+        let profileTabViewController = UINavigationController(rootViewController: ProfileTabViewController())
+        let profileTabViewIcon = UITabBarItem(title: "프로필", image: UIImage(systemName: "person.crop.circle"), selectedImage: UIImage(systemName: "person.crop.circle.fill"))
+        profileTabViewController.tabBarItem = profileTabViewIcon
+        
+        let notificationTabViewController = UINavigationController(rootViewController: NotificationTabViewController())
+        let notificationTabViewIcon = UITabBarItem(title: "알림", image: UIImage(systemName: "bell"), selectedImage: UIImage(systemName: "bell.fill"))
+        notificationTabViewController.tabBarItem = notificationTabViewIcon
+
+        let controllers = [newsfeedTabViewController,
+                           profileTabViewController,
+                           notificationTabViewController]
+        
+        self.viewControllers = controllers
+        self.tabBar.backgroundColor = UIColor.white
+    }
 
 }

--- a/Facebook/Facebook/View/NewsfeedTabView.swift
+++ b/Facebook/Facebook/View/NewsfeedTabView.swift
@@ -1,0 +1,20 @@
+//
+//  NewsfeedTabView.swift
+//  Facebook
+//
+//  Created by 최유림 on 2021/11/24.
+//
+
+import UIKit
+
+class NewsfeedTabView: UIView {
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+}

--- a/Facebook/Facebook/View/NotificationTabView.swift
+++ b/Facebook/Facebook/View/NotificationTabView.swift
@@ -1,0 +1,20 @@
+//
+//  NotificationTabView.swift
+//  Facebook
+//
+//  Created by 최유림 on 2021/11/24.
+//
+
+import UIKit
+
+class NotificationTabView: UIView {
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+}

--- a/Facebook/Facebook/View/ProfileTabView.swift
+++ b/Facebook/Facebook/View/ProfileTabView.swift
@@ -9,6 +9,8 @@ import UIKit
 
 class ProfileTabView: UIView {
 
+    let profilelabel = UILabel()
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
     }

--- a/Facebook/Facebook/View/ProfileTabView.swift
+++ b/Facebook/Facebook/View/ProfileTabView.swift
@@ -1,0 +1,20 @@
+//
+//  ProfileTabView.swift
+//  Facebook
+//
+//  Created by 최유림 on 2021/11/24.
+//
+
+import UIKit
+
+class ProfileTabView: UIView {
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+}


### PR DESCRIPTION
- 기본적인 TabBar(Newsfeed, Profile, Notification) 추가 및 공통 NavigationBar 설정을 위한 BaseViewController
- 각 ViewController에 `private final var profile: ProfileTabView { return view as! View }`와 같은 코드가 있는 이유:

  - view와 관련된 요소는 모두 UIView 파일에 선언하고, 이를 받는 UIViewController에서 바인딩하려고 합니다. 뷰컨의 `override func loadView() { view = View() }` 때문에 `view.menuTable.bind()`와 `profile.menuTable.bind()`은 동일한 코드이긴 하지만 후자가 조금 더 readable할 것 같아서 넣었습니다. 관련해서 의견 있으시다면 리뷰 부탁드립니다.