### PR TITLE
잡다한 버그 수정 및 기능 구현

### DIFF
--- a/Facebook/Facebook.xcodeproj/project.pbxproj
+++ b/Facebook/Facebook.xcodeproj/project.pbxproj
@@ -12,13 +12,9 @@
 		771DF5A127707DD900B69351 /* ImageTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 771DF59F27707DD900B69351 /* ImageTableViewCell.xib */; };
 		774094382750E57100AD8DC2 /* MainProfileTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 774094362750E57100AD8DC2 /* MainProfileTableViewCell.swift */; };
 		774094392750E57100AD8DC2 /* MainProfileTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 774094372750E57100AD8DC2 /* MainProfileTableViewCell.xib */; };
-		7740943E2750E7E400AD8DC2 /* DetailProfileTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7740943C2750E7E400AD8DC2 /* DetailProfileTableViewCell.swift */; };
-		7740943F2750E7E400AD8DC2 /* DetailProfileTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 7740943D2750E7E400AD8DC2 /* DetailProfileTableViewCell.xib */; };
-		77547904275CE66A0065711C /* PostDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77547903275CE66A0065711C /* PostDetailViewController.swift */; };
-		77547907275CE6CC0065711C /* CommentTableViewCellXib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77547905275CE6CC0065711C /* CommentTableViewCellXib.swift */; };
-		7740943E2750E7E400AD8DC2 /* InformationTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7740943C2750E7E400AD8DC2 /* InformationTableViewCell.swift */; };
 		7740943E2750E7E400AD8DC2 /* SimpleInformationTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7740943C2750E7E400AD8DC2 /* SimpleInformationTableViewCell.swift */; };
 		7740944A2750ECDC00AD8DC2 /* ButtonTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 774094482750ECDC00AD8DC2 /* ButtonTableViewCell.swift */; };
+		77547904275CE66A0065711C /* PostDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77547903275CE66A0065711C /* PostDetailViewController.swift */; };
 		77547907275CE6CC0065711C /* CommentTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77547905275CE6CC0065711C /* CommentTableViewCell.swift */; };
 		77547908275CE6CC0065711C /* CommentTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 77547906275CE6CC0065711C /* CommentTableViewCell.xib */; };
 		7754B861277D68D200775D81 /* DetailInformationTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7754B860277D68D200775D81 /* DetailInformationTableViewCell.swift */; };
@@ -43,11 +39,11 @@
 		7779931D2750843C007A3898 /* SearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7779931C2750843B007A3898 /* SearchViewController.swift */; };
 		777993252750D280007A3898 /* NotificationTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 777993232750D280007A3898 /* NotificationTableViewCell.swift */; };
 		777993262750D280007A3898 /* NotificationTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 777993242750D280007A3898 /* NotificationTableViewCell.xib */; };
-		77AC749B275CEDAD00F10BD5 /* PostDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77AC749A275CEDAD00F10BD5 /* PostDetailView.swift */; };
 		77ABC5D42774A906000431E1 /* EditDetailInformationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77ABC5D32774A906000431E1 /* EditDetailInformationView.swift */; };
 		77ABC5D62774A944000431E1 /* EditDetailInformationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77ABC5D52774A944000431E1 /* EditDetailInformationViewController.swift */; };
 		77ABC5D82774A998000431E1 /* AddInformationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77ABC5D72774A998000431E1 /* AddInformationView.swift */; };
 		77ABC5DA2774A9B0000431E1 /* AddInformationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77ABC5D92774A9B0000431E1 /* AddInformationViewController.swift */; };
+		77AC749B275CEDAD00F10BD5 /* PostDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77AC749A275CEDAD00F10BD5 /* PostDetailView.swift */; };
 		77B635422768B2C100C41EB3 /* DetailProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77B635412768B2C100C41EB3 /* DetailProfileView.swift */; };
 		77B635442768B2E200C41EB3 /* DetailProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77B635432768B2E200C41EB3 /* DetailProfileViewController.swift */; };
 		77B635462768B2F900C41EB3 /* EditProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77B635452768B2F900C41EB3 /* EditProfileView.swift */; };
@@ -69,8 +65,8 @@
 		B85D67E2277C9283002CCC04 /* Endpoint+NewUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = B85D67E1277C9283002CCC04 /* Endpoint+NewUser.swift */; };
 		B85D67E4277C964F002CCC04 /* AuthResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = B85D67E3277C964F002CCC04 /* AuthResponse.swift */; };
 		B85D67E6277ECA76002CCC04 /* CurrentUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = B85D67E5277ECA74002CCC04 /* CurrentUser.swift */; };
-		B85D67F22784B5A5002CCC04 /* CommentCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B85D67F12784B5A5002CCC04 /* CommentCell.swift */; };
 		B85D67F027840F16002CCC04 /* AuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B85D67EF27840F16002CCC04 /* AuthManager.swift */; };
+		B85D67F22784B5A5002CCC04 /* CommentCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B85D67F12784B5A5002CCC04 /* CommentCell.swift */; };
 		B86194EE275D28D000957BBC /* EnterUsernameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B86194ED275D28D000957BBC /* EnterUsernameView.swift */; };
 		B86194F0275D290600957BBC /* EnterUsernameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B86194EF275D290600957BBC /* EnterUsernameViewController.swift */; };
 		B86194F2275DC0C200957BBC /* EnterBirthdateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B86194F1275DC0C200957BBC /* EnterBirthdateView.swift */; };
@@ -101,6 +97,7 @@
 		BE0D43672786D29B00E2162F /* CommentPaginationViewModel.swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE0D43662786D29B00E2162F /* CommentPaginationViewModel.swift.swift */; };
 		BE0D43692787235000E2162F /* UIColor+TintColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE0D43682787235000E2162F /* UIColor+TintColors.swift */; };
 		BE0D436B2787631400E2162F /* HapticManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE0D436A2787631400E2162F /* HapticManager.swift */; };
+		BE0D436D278892D600E2162F /* NewsfeedTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE0D436C278892D600E2162F /* NewsfeedTableView.swift */; };
 		BE1F75B12785895000E51A28 /* Spinner.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE1F75B02785895000E51A28 /* Spinner.swift */; };
 		BE1F75B327858A0600E51A28 /* UITableView+BottomSpinner.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE1F75B227858A0600E51A28 /* UITableView+BottomSpinner.swift */; };
 		BE1F75B52785D2C600E51A28 /* InfoButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE1F75B42785D2C600E51A28 /* InfoButton.swift */; };
@@ -155,13 +152,9 @@
 		771DF59F27707DD900B69351 /* ImageTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ImageTableViewCell.xib; sourceTree = "<group>"; };
 		774094362750E57100AD8DC2 /* MainProfileTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainProfileTableViewCell.swift; sourceTree = "<group>"; };
 		774094372750E57100AD8DC2 /* MainProfileTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = MainProfileTableViewCell.xib; sourceTree = "<group>"; };
-		7740943C2750E7E400AD8DC2 /* DetailProfileTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailProfileTableViewCell.swift; sourceTree = "<group>"; };
-		7740943D2750E7E400AD8DC2 /* DetailProfileTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = DetailProfileTableViewCell.xib; sourceTree = "<group>"; };
-		77547903275CE66A0065711C /* PostDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostDetailViewController.swift; sourceTree = "<group>"; };
-		77547905275CE6CC0065711C /* CommentTableViewCellXib.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentTableViewCellXib.swift; sourceTree = "<group>"; };
-		7740943C2750E7E400AD8DC2 /* InformationTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InformationTableViewCell.swift; sourceTree = "<group>"; };
 		7740943C2750E7E400AD8DC2 /* SimpleInformationTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleInformationTableViewCell.swift; sourceTree = "<group>"; };
 		774094482750ECDC00AD8DC2 /* ButtonTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonTableViewCell.swift; sourceTree = "<group>"; };
+		77547903275CE66A0065711C /* PostDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostDetailViewController.swift; sourceTree = "<group>"; };
 		77547905275CE6CC0065711C /* CommentTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentTableViewCell.swift; sourceTree = "<group>"; };
 		77547906275CE6CC0065711C /* CommentTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CommentTableViewCell.xib; sourceTree = "<group>"; };
 		7754B860277D68D200775D81 /* DetailInformationTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailInformationTableViewCell.swift; sourceTree = "<group>"; };
@@ -186,11 +179,11 @@
 		7779931C2750843B007A3898 /* SearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewController.swift; sourceTree = "<group>"; };
 		777993232750D280007A3898 /* NotificationTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationTableViewCell.swift; sourceTree = "<group>"; };
 		777993242750D280007A3898 /* NotificationTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = NotificationTableViewCell.xib; sourceTree = "<group>"; };
-		77AC749A275CEDAD00F10BD5 /* PostDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostDetailView.swift; sourceTree = "<group>"; };
 		77ABC5D32774A906000431E1 /* EditDetailInformationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditDetailInformationView.swift; sourceTree = "<group>"; };
 		77ABC5D52774A944000431E1 /* EditDetailInformationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditDetailInformationViewController.swift; sourceTree = "<group>"; };
 		77ABC5D72774A998000431E1 /* AddInformationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddInformationView.swift; sourceTree = "<group>"; };
 		77ABC5D92774A9B0000431E1 /* AddInformationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddInformationViewController.swift; sourceTree = "<group>"; };
+		77AC749A275CEDAD00F10BD5 /* PostDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostDetailView.swift; sourceTree = "<group>"; };
 		77B635412768B2C100C41EB3 /* DetailProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailProfileView.swift; sourceTree = "<group>"; };
 		77B635432768B2E200C41EB3 /* DetailProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailProfileViewController.swift; sourceTree = "<group>"; };
 		77B635452768B2F900C41EB3 /* EditProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditProfileView.swift; sourceTree = "<group>"; };
@@ -213,8 +206,8 @@
 		B85D67E1277C9283002CCC04 /* Endpoint+NewUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Endpoint+NewUser.swift"; sourceTree = "<group>"; };
 		B85D67E3277C964F002CCC04 /* AuthResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthResponse.swift; sourceTree = "<group>"; };
 		B85D67E5277ECA74002CCC04 /* CurrentUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentUser.swift; sourceTree = "<group>"; };
-		B85D67F12784B5A5002CCC04 /* CommentCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentCell.swift; sourceTree = "<group>"; };
 		B85D67EF27840F16002CCC04 /* AuthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthManager.swift; sourceTree = "<group>"; };
+		B85D67F12784B5A5002CCC04 /* CommentCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentCell.swift; sourceTree = "<group>"; };
 		B86194ED275D28D000957BBC /* EnterUsernameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnterUsernameView.swift; sourceTree = "<group>"; };
 		B86194EF275D290600957BBC /* EnterUsernameViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnterUsernameViewController.swift; sourceTree = "<group>"; };
 		B86194F1275DC0C200957BBC /* EnterBirthdateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnterBirthdateView.swift; sourceTree = "<group>"; };
@@ -247,6 +240,7 @@
 		BE0D43662786D29B00E2162F /* CommentPaginationViewModel.swift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentPaginationViewModel.swift.swift; sourceTree = "<group>"; };
 		BE0D43682787235000E2162F /* UIColor+TintColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+TintColors.swift"; sourceTree = "<group>"; };
 		BE0D436A2787631400E2162F /* HapticManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticManager.swift; sourceTree = "<group>"; };
+		BE0D436C278892D600E2162F /* NewsfeedTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsfeedTableView.swift; sourceTree = "<group>"; };
 		BE1F75B02785895000E51A28 /* Spinner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Spinner.swift; sourceTree = "<group>"; };
 		BE1F75B227858A0600E51A28 /* UITableView+BottomSpinner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+BottomSpinner.swift"; sourceTree = "<group>"; };
 		BE1F75B42785D2C600E51A28 /* InfoButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoButton.swift; sourceTree = "<group>"; };
@@ -458,11 +452,8 @@
 			isa = PBXGroup;
 			children = (
 				BE8015AA276B6CC90014FEFA /* PaginatedResponse.swift */,
-				BE9C7C99276E3F480089247F /* LoginResponse.swift */,
-				BE86BAD42783047500948CAA /* LikeResponse.swift */,
-				B85D67E3277C964F002CCC04 /* SignUpResponse.swift */,
 				B85D67E3277C964F002CCC04 /* AuthResponse.swift */,
-				BE86BAD42783047500948CAA /* PostLikeResponse.swift */,
+				BE86BAD42783047500948CAA /* LikeResponse.swift */,
 			);
 			path = Responses;
 			sourceTree = "<group>";
@@ -562,6 +553,7 @@
 			children = (
 				BE9C7C95276DB3C30089247F /* PostCell.swift */,
 				B897A921274E612B00FB67D3 /* NewsfeedTabView.swift */,
+				BE0D436C278892D600E2162F /* NewsfeedTableView.swift */,
 				BE64AF3627809F5400C25967 /* Headers */,
 				BE827A1227722ABD00BD3566 /* CreatePostTableViewCell.swift */,
 				BE827A1627722B9400BD3566 /* CreatePostTableViewCell.xib */,
@@ -575,16 +567,6 @@
 				B897A91E274E389000FB67D3 /* NewsfeedTabViewController.swift */,
 			);
 			path = Controllers;
-			sourceTree = "<group>";
-		};
-		BE9C7CAA2771706A0089247F /* Profile */ = {
-			isa = PBXGroup;
-			children = (
-				7754B868277F33ED00775D81 /* Models */,
-				BE9C7CAC277170840089247F /* Controllers */,
-				BE9C7CAB2771707A0089247F /* Views */,
-			);
-			path = Profile;
 			sourceTree = "<group>";
 		};
 		BE9C7CAB2771707A0089247F /* Views */ = {
@@ -616,23 +598,6 @@
 				7754B8742781DD9A00775D81 /* GenderSelectTableViewCell.swift */,
 			);
 			path = Views;
-			sourceTree = "<group>";
-		};
-		BE9C7CAC277170840089247F /* Controllers */ = {
-			isa = PBXGroup;
-			children = (
-				B897A918274E378300FB67D3 /* ProfileTabViewController.swift */,
-				77B635432768B2E200C41EB3 /* DetailProfileViewController.swift */,
-				77B635472768B30A00C41EB3 /* EditProfileViewController.swift */,
-				77ABC5D52774A944000431E1 /* EditDetailInformationViewController.swift */,
-				7754B864277DAE5300775D81 /* AddSelfIntroViewController.swift */,
-				77ABC5D92774A9B0000431E1 /* AddInformationViewController.swift */,
-				77FE72882775E0A100482CE7 /* SelectInformationViewController.swift */,
-				7754B8702781D66400775D81 /* EditUserProfileViewController.swift */,
-				7754B87A2782A0CC00775D81 /* EditUsernameViewController.swift */,
-				7754B8832782C27D00775D81 /* PhotoPopUpViewController.swift */,
-			);
-			path = Controllers;
 			sourceTree = "<group>";
 		};
 		BE9C7CAE277171320089247F /* Notification */ = {
@@ -764,7 +729,7 @@
 				77AC749A275CEDAD00F10BD5 /* PostDetailView.swift */,
 				BEF254F3277B0DC500FBAACB /* PostDetailHeaderView.swift */,
 				77547906275CE6CC0065711C /* CommentTableViewCell.xib */,
-				77547905275CE6CC0065711C /* CommentTableViewCellXib.swift */,
+				77547905275CE6CC0065711C /* CommentTableViewCell.swift */,
 				77799318274FD8E4007A3898 /* PostTableViewCell.swift */,
 				BE86BAD627830F7600948CAA /* CommentTableViewCell.swift */,
 				77799319274FD8E4007A3898 /* PostTableViewCell.xib */,
@@ -926,13 +891,12 @@
 			buildActionMask = 2147483647;
 			files = (
 				BE827A1727722B9400BD3566 /* CreatePostTableViewCell.xib in Resources */,
-				771DF5A127707DD900B69351 /* ProfileImageTableViewCell.xib in Resources */,
+				771DF5A127707DD900B69351 /* ImageTableViewCell.xib in Resources */,
 				777993262750D280007A3898 /* NotificationTableViewCell.xib in Resources */,
 				7779931B274FD8E4007A3898 /* PostTableViewCell.xib in Resources */,
 				771DF5A127707DD900B69351 /* ImageTableViewCell.xib in Resources */,
 				777993262750D280007A3898 /* NotificationTableViewCell.xib in Resources */,
 				7779931B274FD8E4007A3898 /* PostTableViewCell.xib in Resources */,
-				777993222750CD41007A3898 /* CreatePostTableViewCell.xib in Resources */,
 				B897A90A274E303700FB67D3 /* LaunchScreen.storyboard in Resources */,
 				774094392750E57100AD8DC2 /* MainProfileTableViewCell.xib in Resources */,
 				B897A907274E303700FB67D3 /* Assets.xcassets in Resources */,
@@ -1003,7 +967,7 @@
 				BE9C7C9D276E413B0089247F /* URL+QueryParameters.swift in Sources */,
 				BEDA608327845F2F0002A231 /* PlaceholderTextView.swift in Sources */,
 				B85D67E02775AC04002CCC04 /* NewUser.swift in Sources */,
-				77547907275CE6CC0065711C /* CommentTableViewCellXib.swift in Sources */,
+				77547907275CE6CC0065711C /* CommentTableViewCell.swift in Sources */,
 				B85D67F22784B5A5002CCC04 /* CommentCell.swift in Sources */,
 				BE86BAD727830F7600948CAA /* CommentTableViewCell.swift in Sources */,
 				BE0D436B2787631400E2162F /* HapticManager.swift in Sources */,
@@ -1023,12 +987,11 @@
 				B8A7F8322761FCEB00F659D2 /* EnterPasswordViewController.swift in Sources */,
 				B846BDA72754F35800513B77 /* LoginView.swift in Sources */,
 				BE827A11277223A100BD3566 /* CreatePostHeaderView.swift in Sources */,
-				777993212750CD41007A3898 /* CreatePostTableViewCell.swift in Sources */,
 				7754B8712781D66400775D81 /* EditUserProfileViewController.swift in Sources */,
 				77ABC5DA2774A9B0000431E1 /* AddInformationViewController.swift in Sources */,
 				B897A926274E61D800FB67D3 /* NotificationTabView.swift in Sources */,
 				B846BDAA2754F5A900513B77 /* FacebookColor.swift in Sources */,
-				7740943E2750E7E400AD8DC2 /* DetailProfileTableViewCell.swift in Sources */,
+				7740943E2750E7E400AD8DC2 /* SimpleInformationTableViewCell.swift in Sources */,
 				BE86BAE02784012F00948CAA /* CustomInputAccessoryView.swift in Sources */,
 				7740943E2750E7E400AD8DC2 /* SimpleInformationTableViewCell.swift in Sources */,
 				B897A91F274E389000FB67D3 /* NewsfeedTabViewController.swift in Sources */,
@@ -1037,13 +1000,14 @@
 				77B635462768B2F900C41EB3 /* EditProfileView.swift in Sources */,
 				777993252750D280007A3898 /* NotificationTableViewCell.swift in Sources */,
 				BEF254EE277B062800FBAACB /* PostContentLabel.swift in Sources */,
-				771DF5A027707DD900B69351 /* ProfileImageTableViewCell.swift in Sources */,
+				771DF5A027707DD900B69351 /* ImageTableViewCell.swift in Sources */,
 				77547904275CE66A0065711C /* PostDetailViewController.swift in Sources */,
 				771DF5A027707DD900B69351 /* ImageTableViewCell.swift in Sources */,
 				7754B8752781DD9A00775D81 /* GenderSelectTableViewCell.swift in Sources */,
 				B846BDAC2754FEFB00513B77 /* RectangularSlimButton.swift in Sources */,
 				7754B86D2781A0B900775D81 /* Endpoint+Profile.swift in Sources */,
 				777993252750D280007A3898 /* NotificationTableViewCell.swift in Sources */,
+				BE0D436D278892D600E2162F /* NewsfeedTableView.swift in Sources */,
 				B8619503276103AE00957BBC /* SelectGenderView.swift in Sources */,
 				BE7D1DFB277E089F00E080E3 /* Rx+Upload.swift in Sources */,
 				B85D67F027840F16002CCC04 /* AuthManager.swift in Sources */,

--- a/Facebook/Facebook/Components/CommentCell/CommentCell.swift
+++ b/Facebook/Facebook/Components/CommentCell/CommentCell.swift
@@ -65,6 +65,8 @@ class CommentCell: UITableViewCell {
         
         if let urlString = comment.author.profile_image {
             profileImage.setImage(from: URL(string: urlString))
+        } else {
+            profileImage.setImage(from: nil)
         }
         
         profileImage.snp.updateConstraints { make in

--- a/Facebook/Facebook/Components/CommentCell/CommentCell.swift
+++ b/Facebook/Facebook/Components/CommentCell/CommentCell.swift
@@ -64,6 +64,10 @@ class CommentCell: UITableViewCell {
         contentLabel.text = comment.content
         createdLabel.text = comment.posted_at
         
+        if let urlString = comment.author.profile_image {
+            profileImage.setImage(from: URL(string: urlString))
+        }
+        
         profileImage.snp.updateConstraints { make in
             make.height.width.equalTo(comment.profileImageSize)
             make.leading.equalTo(comment.leftMargin)
@@ -98,7 +102,7 @@ class CommentCell: UITableViewCell {
         likeCountLabelWithIcon.snp.makeConstraints { make in
             make.centerY.equalTo(horizontalButtonStack).offset(-2)
             make.trailing.equalTo(contentView).offset(CGFloat.standardTrailingMargin)
-//            make.height.equalTo(horizontalButtonStack)
+            //            make.height.equalTo(horizontalButtonStack)
         }
     }
     

--- a/Facebook/Facebook/Components/CommentCell/CommentCell.swift
+++ b/Facebook/Facebook/Components/CommentCell/CommentCell.swift
@@ -31,7 +31,6 @@ class CommentCell: UITableViewCell {
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: CommentCell.reuseIdentifier)
         setLayout()
-        bind()
     }
     
     required init?(coder: NSCoder) {
@@ -106,14 +105,6 @@ class CommentCell: UITableViewCell {
         }
     }
     
-    private func bind() {
-        profileImage.rx.tapGesture().when(.recognized)
-            .bind { [weak self] _ in
-                print("profile Image tapped")
-                // move to user profile view
-            }.disposed(by: disposeBag)
-    }
-    
     // MARK: Public Functions
     
     func focus() {
@@ -163,8 +154,8 @@ class CommentCell: UITableViewCell {
         return bubbleView
     }()
     
-    private let profileImage = ProfileImageView()
-    private let authorLabel: InfoButton = {
+    let profileImage = ProfileImageView()
+    let authorLabel: InfoButton = {
         let button = InfoButton(color: .label, size: 13, weight: .semibold)
         button.setContentHuggingPriority(.required, for: .horizontal)
         return button

--- a/Facebook/Facebook/Components/Labels/PostContentLabel.swift
+++ b/Facebook/Facebook/Components/Labels/PostContentLabel.swift
@@ -20,7 +20,7 @@ class PostContentLabel: UILabel {
     init() {
         super.init(frame: .zero)
         self.textColor = .label
-        self.numberOfLines = 3
+        self.numberOfLines = 0
         self.font = .systemFont(ofSize: 16)
         self.translatesAutoresizingMaskIntoConstraints = false
         

--- a/Facebook/Facebook/Components/PostCell/AuthorInfoHeaderView.swift
+++ b/Facebook/Facebook/Components/PostCell/AuthorInfoHeaderView.swift
@@ -50,6 +50,8 @@ class AuthorInfoHeaderView: UIView {
         postDateLabel.text = post.posted_at
         if let urlString = post.author?.profile_image {
             profileImageView.setImage(from: URL(string: urlString))
+        } else {
+            profileImageView.setImage(from: nil)
         }
     }
     

--- a/Facebook/Facebook/Components/PostCell/AuthorInfoHeaderView.swift
+++ b/Facebook/Facebook/Components/PostCell/AuthorInfoHeaderView.swift
@@ -48,6 +48,9 @@ class AuthorInfoHeaderView: UIView {
     func configure(with post: Post) {
         authorNameLabel.text = post.author?.username
         postDateLabel.text = post.posted_at
+        if let urlString = post.author?.profile_image {
+            profileImageView.setImage(from: URL(string: urlString))
+        }
     }
     
     required init?(coder: NSCoder) {

--- a/Facebook/Facebook/Components/PostCell/AuthorInfoHeaderView.swift
+++ b/Facebook/Facebook/Components/PostCell/AuthorInfoHeaderView.swift
@@ -26,7 +26,6 @@ class AuthorInfoHeaderView: UIView {
             profileImageView.heightAnchor.constraint(equalToConstant: imageWidth)
         ])
         
-        let labelStack = UIView()
         labelStack.translatesAutoresizingMaskIntoConstraints = false
         labelStack.addSubview(authorNameLabel)
         labelStack.addSubview(postDateLabel)
@@ -46,7 +45,7 @@ class AuthorInfoHeaderView: UIView {
     }
     
     func configure(with post: Post) {
-        authorNameLabel.text = post.author?.username
+        authorNameLabel.text = post.author?.username ?? "알 수 없음"
         postDateLabel.text = post.posted_at
         if let urlString = post.author?.profile_image {
             profileImageView.setImage(from: URL(string: urlString))
@@ -57,11 +56,13 @@ class AuthorInfoHeaderView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
+    let labelStack = UIView()
+    
     // Profile Image가 표시되는 뷰 (현재는 아이콘으로 구현)
-    private let profileImageView = ProfileImageView()
+    let profileImageView = ProfileImageView()
     
     // 작성자 이름 라벨
-    private let authorNameLabel: UILabel = InfoLabel(color: .label, size: 16, weight: .medium)
+    let authorNameLabel: InfoLabel = InfoLabel(color: .label, size: 16, weight: .medium)
     
     // 작성 시간 라벨
     private let postDateLabel: UILabel = InfoLabel()

--- a/Facebook/Facebook/Components/PostCell/AuthorInfoHeaderView.swift
+++ b/Facebook/Facebook/Components/PostCell/AuthorInfoHeaderView.swift
@@ -20,12 +20,13 @@ class AuthorInfoHeaderView: UIView {
         
         self.addSubview(profileImageView)
         NSLayoutConstraint.activate([
-            profileImageView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: -3),
+            profileImageView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
             profileImageView.centerYAnchor.constraint(equalTo: self.centerYAnchor),
             profileImageView.widthAnchor.constraint(equalToConstant: imageWidth),
             profileImageView.heightAnchor.constraint(equalToConstant: imageWidth)
         ])
         
+        let labelStack = UIView()
         labelStack.translatesAutoresizingMaskIntoConstraints = false
         labelStack.addSubview(authorNameLabel)
         labelStack.addSubview(postDateLabel)
@@ -55,8 +56,6 @@ class AuthorInfoHeaderView: UIView {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
-    let labelStack = UIView()
     
     // Profile Image가 표시되는 뷰 (현재는 아이콘으로 구현)
     let profileImageView = ProfileImageView()

--- a/Facebook/Facebook/Components/PostCell/ProfileImageView.swift
+++ b/Facebook/Facebook/Components/PostCell/ProfileImageView.swift
@@ -6,23 +6,39 @@
 //
 
 import UIKit
+import Kingfisher
 
-class ProfileImageView: UIImageView {
-
-    /*
-    // Only override draw() if you perform custom drawing.
-    // An empty implementation adversely affects performance during animation.
-    override func draw(_ rect: CGRect) {
-        // Drawing code
-    }
-    */
+class ProfileImageView: UIView {
+    private var imageView = UIImageView()
     
     override init(frame: CGRect) {
         super.init(frame: frame)
-        let config = UIImage.SymbolConfiguration(hierarchicalColor: .systemFill)
-        self.image = UIImage(systemName: "person.crop.circle.fill", withConfiguration: config)
-        self.contentMode = .scaleAspectFit
+        
+        self.addSubview(imageView)
+        
+        imageView.image = UIImage(systemName: "person.fill")
+        imageView.contentMode = .scaleAspectFill
+        imageView.tintColor = .secondarySystemFill
+        
         self.translatesAutoresizingMaskIntoConstraints = false
+        self.clipsToBounds = true
+        self.layer.cornerRadius = self.frame.width
+        self.backgroundColor = .grayscales.bubbleFocused
+        
+        imageView.snp.makeConstraints { make in
+            make.height.equalTo(30)
+            make.centerX.centerY.equalTo(self)
+        }
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        self.layer.cornerRadius = self.frame.width / 2
+    }
+    
+    convenience init(from url: URL?) {
+        self.init(frame: .zero)
+        setImage(from: url)
     }
     
     required init?(coder: NSCoder) {
@@ -31,6 +47,23 @@ class ProfileImageView: UIImageView {
     
     convenience init() {
         self.init(frame: .zero)
+    }
+    
+    func setImage(from url: URL?) {
+        guard let url = url else {
+            return
+        }
+        imageView.snp.remakeConstraints { make in
+            make.edges.equalTo(0)
+        }
+        let processor = DownsamplingImageProcessor(size: CGSize(width: 400, height: 400))
+        KF.url(url)
+          .setProcessor(processor)
+          .loadDiskFileSynchronously()
+          .cacheMemoryOnly()
+          .fade(duration: 0.1)
+          .onFailure { error in print("로딩 실패", error)}
+          .set(to: self.imageView)
     }
     
 }

--- a/Facebook/Facebook/Components/PostCell/ProfileImageView.swift
+++ b/Facebook/Facebook/Components/PostCell/ProfileImageView.swift
@@ -16,7 +16,6 @@ class ProfileImageView: UIView {
         
         self.addSubview(imageView)
         
-        imageView.image = UIImage(systemName: "person.fill")
         imageView.contentMode = .scaleAspectFill
         imageView.tintColor = .secondarySystemFill
         
@@ -25,10 +24,7 @@ class ProfileImageView: UIView {
         self.layer.cornerRadius = self.frame.width
         self.backgroundColor = .grayscales.bubbleFocused
         
-        imageView.snp.makeConstraints { make in
-            make.height.equalTo(30)
-            make.centerX.centerY.equalTo(self)
-        }
+        setImage(from: nil)
     }
     
     override func layoutSubviews() {
@@ -51,6 +47,11 @@ class ProfileImageView: UIView {
     
     func setImage(from url: URL?) {
         guard let url = url else {
+            imageView.image = UIImage(systemName: "person.fill")
+            imageView.snp.remakeConstraints { make in
+                make.height.equalTo(30)
+                make.centerX.centerY.equalTo(self)
+            }
             return
         }
         imageView.snp.remakeConstraints { make in

--- a/Facebook/Facebook/Extensions/CGFloat+LayoutConstants.swift
+++ b/Facebook/Facebook/Extensions/CGFloat+LayoutConstants.swift
@@ -15,6 +15,6 @@ extension CGFloat {
     static var standardBottomMargin: CGFloat = -10
     
     static var gradientIconWidth: CGFloat = 16
-    static var profileImageSize: CGFloat = 50
+    static var profileImageSize: CGFloat = 40
     static var buttonGroupHeight: CGFloat = 37.5
 }

--- a/Facebook/Facebook/Features/Newsfeed/Controllers/NewsfeedTabViewController.swift
+++ b/Facebook/Facebook/Features/Newsfeed/Controllers/NewsfeedTabViewController.swift
@@ -161,15 +161,13 @@ extension UIViewController {
                 self?.pushToDetailVC(cell: cell, asFirstResponder: true)
             }.disposed(by: cell.disposeBag)
         
-        // 셀 헤더 부분 터치 시 디테일 화면으로 이동
-        cell.postHeader.rx.tapGesture(configuration: { _, delegate in
-            delegate.touchReceptionPolicy = .custom { _, shouldReceive in
-                return !(shouldReceive.view is UIControl)
-            }
-        })
-            .when(.recognized)
+        let authorNameTapped = cell.postHeader.authorNameLabel.rx.tapGesture().when(.recognized)  // not working...
+        let profileImageTapped = cell.postHeader.profileImageView.rx.tapGesture().when(.recognized)
+        Observable.of(profileImageTapped, authorNameTapped)
+            .merge()
             .bind { [weak self] _ in
-                self?.pushToDetailVC(cell: cell, asFirstResponder: false)
+                let profileVC = ProfileTabViewController(userId: post.author?.id)
+                self?.push(viewController: profileVC)
             }
             .disposed(by: cell.disposeBag)
         

--- a/Facebook/Facebook/Features/Newsfeed/Views/Headers/CreatePostHeaderView.swift
+++ b/Facebook/Facebook/Features/Newsfeed/Views/Headers/CreatePostHeaderView.swift
@@ -29,8 +29,8 @@ class CreatePostHeaderView: UIView {
         self.addSubview(profileImage)
         NSLayoutConstraint.activate([
             profileImage.centerYAnchor.constraint(equalTo: self.centerYAnchor),
-            profileImage.widthAnchor.constraint(equalToConstant: 50),
-            profileImage.heightAnchor.constraint(equalToConstant: 50),
+            profileImage.widthAnchor.constraint(equalToConstant: .profileImageSize),
+            profileImage.heightAnchor.constraint(equalToConstant: .profileImageSize),
             profileImage.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 12)
         ])
         
@@ -50,12 +50,11 @@ class CreatePostHeaderView: UIView {
         ])
     }
     
-    private lazy var profileImage: UIImageView = {
-        let config = UIImage.SymbolConfiguration(hierarchicalColor: .systemFill)
-        let image = UIImage(systemName: "person.crop.circle.fill", withConfiguration: config)
-        let imageView = UIImageView(image: image)
-        imageView.contentMode = .scaleAspectFit
-        imageView.translatesAutoresizingMaskIntoConstraints = false
+    private var profileImage: ProfileImageView = {
+        let imageView = ProfileImageView()
+        if let string = CurrentUser.shared.profile?.profile_image {
+            imageView.setImage(from: URL(string: string))
+        }
         return imageView
     }()
     

--- a/Facebook/Facebook/Features/Newsfeed/Views/NewsfeedTableView.swift
+++ b/Facebook/Facebook/Features/Newsfeed/Views/NewsfeedTableView.swift
@@ -1,0 +1,20 @@
+//
+//  NewsfeedTableView.swift
+//  Facebook
+//
+//  Created by 박신홍 on 2022/01/08.
+//
+
+import Foundation
+import UIKit
+
+class NewsfeedTableView: ResponsiveTableView {
+    
+    override func touchesShouldCancel(in view: UIView) -> Bool {
+//        print(view)
+//        if view is AuthorInfoHeaderView {
+//            return true
+//        }
+        return super.touchesShouldCancel(in: view)
+    }
+}

--- a/Facebook/Facebook/Features/Newsfeed/Views/PostCell.swift
+++ b/Facebook/Facebook/Features/Newsfeed/Views/PostCell.swift
@@ -37,6 +37,7 @@ class PostCell: UITableViewCell {
         didSet {
             likeCountLabel.text = post.likes.withCommas(unit: "개")
             likeButton.isSelected = post.is_liked
+            commentCountButton.text = "댓글 \(post.comments.withCommas(unit: "개"))"
             layoutIfNeeded()
         }
     }
@@ -66,7 +67,6 @@ class PostCell: UITableViewCell {
     
     func configureCell(with newPost: Post) {
         post = newPost
-        commentCountButton.text = "댓글 \(post.comments.withCommas(unit: "개"))"
         textContentLabel.text = post.content
         postHeader.configure(with: post)
         

--- a/Facebook/Facebook/Features/PostDetail/Controllers/PostDetailViewController.swift
+++ b/Facebook/Facebook/Features/PostDetail/Controllers/PostDetailViewController.swift
@@ -82,7 +82,7 @@ class PostDetailViewController: UIViewController, UIGestureRecognizerDelegate {
     }
     
     lazy var authorHeaderView: AuthorInfoHeaderView = {
-        let view = AuthorInfoHeaderView(imageWidth: 40)
+        let view = AuthorInfoHeaderView(imageWidth: 38)
         view.configure(with: post)
         return view
     }()

--- a/Facebook/Facebook/Features/PostDetail/Controllers/PostDetailViewController.swift
+++ b/Facebook/Facebook/Features/PostDetail/Controllers/PostDetailViewController.swift
@@ -308,6 +308,10 @@ extension PostDetailViewController {
                             let indexPath = self.commentViewModel.findInsertionIndexPath(of: comment)
                             self.commentViewModel.insert(comment, at: indexPath)
                             self.commentTableView.scrollToRow(at: indexPath, at: .bottom, animated: true)
+                            
+                            var commentIncrementedPost = self.post
+                            commentIncrementedPost.comments += 1
+                            self.postView.postContentHeaderView.postUpdated.accept(commentIncrementedPost)
                         }
                     }, onError: { error in
                         print(error)

--- a/Facebook/Facebook/Features/PostDetail/Controllers/PostDetailViewController.swift
+++ b/Facebook/Facebook/Features/PostDetail/Controllers/PostDetailViewController.swift
@@ -231,6 +231,18 @@ extension PostDetailViewController {
                     cell.focus()
                 }
                 
+                let b = cell.authorLabel.rx.tap.map{ return true }
+                let a = cell.profileImage.rx.tapGesture().when(.recognized).map{ _ in return true }
+                
+                Observable.of(a, b)
+                    .merge()
+                    .bind { [weak self] _ in
+                        let profileVC = ProfileTabViewController(userId: comment.author.id)
+                        self?.push(viewController: profileVC)
+                    }
+                    .disposed(by: cell.disposeBag)
+                
+                
                 cell.likeButton.rx.tap
                     .bind { [weak self] _ in
                         guard let self = self else { return }


### PR DESCRIPTION
- 프로필 이미지 보이도록 수정했습니다. 
- 뉴스피드, 댓글에서 프로필 이미지 탭하면 해당 유저의 프로필 페이지로 넘어가는 기능을 구현했는데, 이상하게 뉴스피드의 author label에만 `tapGesture`가 안먹고 있습니다. 원인 파악은 총회 이후로 해야할 것 같습니다 ㅠㅠ