### PR TITLE
오토레이아웃 오류 수정

### DIFF
--- a/Facebook/Facebook/Features/Profile/Views/ImageTableViewCell.swift
+++ b/Facebook/Facebook/Features/Profile/Views/ImageTableViewCell.swift
@@ -25,7 +25,6 @@ class ImageTableViewCell: UITableViewCell {
     override func prepareForReuse() {
         super.prepareForReuse()
         disposeBag = DisposeBag() // because life cicle of every cell ends on prepare for reuse
-        resetCell()
     }
     
     override func awakeFromNib() {
@@ -38,10 +37,6 @@ class ImageTableViewCell: UITableViewCell {
         super.setSelected(selected, animated: animated)
 
         // Configure the view for the selected state
-    }
-    
-    func resetCell() {
-        self.removeConstraints(self.constraints)
     }
     
     func configureCell(cellStyle: Style, imageUrl: String){

--- a/Facebook/Facebook/Features/Profile/Views/ImageTableViewCell.swift
+++ b/Facebook/Facebook/Features/Profile/Views/ImageTableViewCell.swift
@@ -47,10 +47,9 @@ class ImageTableViewCell: UITableViewCell {
             switch self.cellStyle {
             case .profileImage:
                 imgView.snp.remakeConstraints { make in
-                    make.height.equalTo(225)
-                    make.leading.trailing.equalTo(self).inset(CGFloat.standardLeadingMargin)
+                    make.height.width.equalTo(175)
                 }
-                imgView.layer.cornerRadius = 5
+                imgView.layer.cornerRadius = 175 / 2
                 imgView.image = UIImage(systemName: "person.circle.fill")
                 imgView.contentMode = .center
             case .coverImage:

--- a/Facebook/Facebook/Features/Profile/Views/ImageTableViewCell.swift
+++ b/Facebook/Facebook/Features/Profile/Views/ImageTableViewCell.swift
@@ -42,7 +42,6 @@ class ImageTableViewCell: UITableViewCell {
     
     func resetCell() {
         self.removeConstraints(self.constraints)
-        imgView.removeConstraints(imgView.constraints)
     }
     
     func configureCell(cellStyle: Style, imageUrl: String){
@@ -52,20 +51,18 @@ class ImageTableViewCell: UITableViewCell {
         }else {
             switch self.cellStyle {
             case .profileImage:
-                NSLayoutConstraint.activate([
-                    imgView.heightAnchor.constraint(equalToConstant: 225),
-                    imgView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 15),
-                    imgView.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -15)
-                ])
+                imgView.snp.remakeConstraints { make in
+                    make.height.equalTo(225)
+                    make.leading.trailing.equalTo(self).inset(CGFloat.standardLeadingMargin)
+                }
                 imgView.layer.cornerRadius = 5
                 imgView.image = UIImage(systemName: "person.circle.fill")
                 imgView.contentMode = .center
             case .coverImage:
-                NSLayoutConstraint.activate([
-                    imgView.heightAnchor.constraint(equalToConstant: 225),
-                    imgView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 15),
-                    imgView.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -15)
-                ])
+                imgView.snp.remakeConstraints { make in
+                    make.height.equalTo(225)
+                    make.leading.trailing.equalTo(self).inset(CGFloat.standardLeadingMargin)
+                }
                 imgView.layer.cornerRadius = 5
                 imgView.image = UIImage(systemName: "photo")
                 imgView.contentMode = .center
@@ -87,19 +84,17 @@ extension ImageTableViewCell {
         
         switch cellStyle {
         case .profileImage:
-            NSLayoutConstraint.activate([
-                imgView.heightAnchor.constraint(equalToConstant: 175),
-                imgView.widthAnchor.constraint(equalToConstant: 175)
-            ])
+            imgView.snp.remakeConstraints { make in
+                make.height.width.equalTo(175)
+            }
             imgView.layer.cornerRadius = 175 / 2
             imgView.clipsToBounds = true
             imgView.contentMode = .scaleAspectFill
         case .coverImage:
-            NSLayoutConstraint.activate([
-                imgView.heightAnchor.constraint(equalToConstant: 225),
-                imgView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 15),
-                imgView.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -15)
-            ])
+            imgView.snp.remakeConstraints { make in
+                make.height.equalTo(225)
+                make.leading.trailing.equalTo(self).inset(CGFloat.standardLeadingMargin)
+            }
             imgView.layer.cornerRadius = 5
             imgView.contentMode = .scaleAspectFill
         }


### PR DESCRIPTION
프로필 페이지에서 아래와 같은 오토레이아웃 오류가 발생해서 Snapkit을 활용해서 수정해보았습니다.

```
2022-01-11 11:14:56.399307+0900 Facebook[63282:6944430] [LayoutConstraints] Unable to simultaneously satisfy constraints.
	Probably at least one of the constraints in the following list is one you don't want. 
	Try this: 
		(1) look at each constraint and try to figure out which you don't expect; 
		(2) find the code that added the unwanted constraint or constraints and fix it. 
(
    "<NSLayoutConstraint:0x6000015abde0 UIImageView:0x7f8fc42796d0.height == 225   (active)>",
    "<NSLayoutConstraint:0x600001592e40 UIImageView:0x7f8fc42796d0.height == 175   (active)>"
)
```

constraint가 제대로 해제되지 않은 상태에서 새로운 constraint가 추가된 것 같아서 Snapkit의 `remakeConstraints`를 사용했습니다.

근데 뭔가 이상한점이 있어서, 그부분은 리뷰로 남기겠습니다. @KWSMooBang 확인 부탁드립니다.