### PR TITLE
체크박스 토글 이슈 수정

### DIFF
--- a/Facebook/Facebook/Features/Profile/Controllers/AddInformationViewController.swift
+++ b/Facebook/Facebook/Features/Profile/Controllers/AddInformationViewController.swift
@@ -430,6 +430,37 @@ class AddInformationViewController<View: AddInformationView>: UIViewController, 
                 }
                 self.addInformationView.layoutIfNeeded()
             }).disposed(by: disposeBag)
+        
+        sectionSwitch.rx.tap.bind { [weak self]  in
+            guard let self = self else { return }
+            switch self.informationType {
+            case .company:
+                if self.companyInformation.is_active! {
+                    self.sectionSwitch.setImage(UIImage(systemName: "square")!, for: .normal)
+                    self.sectionSwitch.tintColor = .gray
+                    self.companyInformation.is_active = false
+                    self.createNotActiveSection()
+                } else {
+                    self.sectionSwitch.setImage(UIImage(systemName: "checkmark.square.fill")!, for: .normal)
+                    self.sectionSwitch.tintColor = .systemBlue
+                    self.companyInformation.is_active = true
+                    self.createActiveSection()
+                }
+            case .university:
+                if self.universityInformation.is_active! {
+                    self.sectionSwitch.setImage(UIImage(systemName: "square")!, for: .normal)
+                    self.sectionSwitch.tintColor = .gray
+                    self.universityInformation.is_active = false
+                    self.createNotActiveSection()
+                } else {
+                    self.sectionSwitch.setImage(UIImage(systemName: "checkmark.square.fill")!, for: .normal)
+                    self.sectionSwitch.tintColor = .systemBlue
+                    self.universityInformation.is_active = true
+                    self.createActiveSection()
+                }
+            }
+        }.disposed(by: disposeBag)
+    
     }
     
     private func saveData() {
@@ -632,9 +663,15 @@ class AddInformationViewController<View: AddInformationView>: UIViewController, 
         }
     }
     
+    let sectionSwitch: UIButton = {
+        let sectionSwitch = UIButton()
+        sectionSwitch.setImage(UIImage(systemName: "checkmark.square.fill")!, for: .normal)
+        sectionSwitch.tintColor = .systemBlue
+        return sectionSwitch
+    }()
+    
     //UITableView의 custom header적용
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-    
         if section == 0 { return UIView() }
         
         let frame = CGRect(x: 0, y: 0, width: view.bounds.width, height: 42)
@@ -645,11 +682,6 @@ class AddInformationViewController<View: AddInformationView>: UIViewController, 
         sectionLabel.text = (informationType == .company) ? "현재 재직 중" : "현재 재학 중"
         sectionLabel.textColor = .black
         sectionLabel.font = UIFont.systemFont(ofSize: 18)
-        
-        let sectionSwitch = UIButton()
-        //sectionSwitch.onTintColor = .systemBlue
-        sectionSwitch.setImage(UIImage(systemName: "checkmark.square.fill")!, for: .normal)
-        sectionSwitch.tintColor = .systemBlue
         
         headerView.addSubview(sectionLabel)
         headerView.addSubview(sectionSwitch)
@@ -666,36 +698,6 @@ class AddInformationViewController<View: AddInformationView>: UIViewController, 
             sectionSwitch.trailingAnchor.constraint(equalTo: headerView.trailingAnchor,constant: -15)
         ])
         
-        sectionSwitch.rx.tap.bind { [weak self]  in
-            guard let self = self else { return }
-            switch self.informationType {
-            case .company:
-                if self.companyInformation.is_active! {
-                    sectionSwitch.setImage(UIImage(systemName: "square")!, for: .normal)
-                    sectionSwitch.tintColor = .gray
-                    self.companyInformation.is_active = false
-                    self.createNotActiveSection()
-                } else {
-                    sectionSwitch.setImage(UIImage(systemName: "checkmark.square.fill")!, for: .normal)
-                    sectionSwitch.tintColor = .systemBlue
-                    self.companyInformation.is_active = true
-                    self.createActiveSection()
-                }
-            case .university:
-                if self.universityInformation.is_active! {
-                    sectionSwitch.setImage(UIImage(systemName: "square")!, for: .normal)
-                    sectionSwitch.tintColor = .gray
-                    self.universityInformation.is_active = false
-                    self.createNotActiveSection()
-                } else {
-                    sectionSwitch.setImage(UIImage(systemName: "checkmark.square.fill")!, for: .normal)
-                    sectionSwitch.tintColor = .systemBlue
-                    self.universityInformation.is_active = true
-                    self.createActiveSection()
-                }
-            }
-        }.disposed(by: disposeBag)
-    
         return headerView
     }
     

--- a/Facebook/Facebook/Features/Profile/Views/AddInformationView.swift
+++ b/Facebook/Facebook/Features/Profile/Views/AddInformationView.swift
@@ -10,10 +10,10 @@ import UIKit
 class AddInformationView: UIView {
 
     let addInformationTableView = UITableView(frame: .zero, style: .grouped)
+    
     let footerView: UIView = {
         let view = UIView()
         view.backgroundColor = .white
-        view.translatesAutoresizingMaskIntoConstraints = false
         
         return view
     }()
@@ -24,7 +24,6 @@ class AddInformationView: UIView {
         button.setTitleColor(.white, for: .normal)
         button.backgroundColor = .systemBlue
         button.layer.cornerRadius = 5
-        button.translatesAutoresizingMaskIntoConstraints = false
         
         return button
     }()
@@ -33,7 +32,6 @@ class AddInformationView: UIView {
     
     override init(frame: CGRect) {
         super.init(frame: frame)
-        addInformationTableView.backgroundColor = .systemGray5
         setLayoutForView()
         configureTableView()
     }
@@ -44,44 +42,33 @@ class AddInformationView: UIView {
     
     private func setLayoutForView() {
         self.addSubview(addInformationTableView)
-        addInformationTableView.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            addInformationTableView.topAnchor.constraint(equalTo: self.safeAreaLayoutGuide.topAnchor),
-            addInformationTableView.bottomAnchor.constraint(equalTo: self.safeAreaLayoutGuide.bottomAnchor),
-            addInformationTableView.leadingAnchor.constraint(equalTo: self.safeAreaLayoutGuide.leadingAnchor),
-            addInformationTableView.trailingAnchor.constraint(equalTo: self.safeAreaLayoutGuide.trailingAnchor)
-        ])
-        
-        footerView.frame = CGRect(x: 0, y: 0, width: addInformationTableView.frame.width, height: 50)
+        addInformationTableView.snp.makeConstraints { make in
+            make.edges.equalTo(self.safeAreaLayoutGuide)
+        }
         
         footerView.addSubview(saveButton)
-        NSLayoutConstraint.activate([
-            saveButton.topAnchor.constraint(equalTo: footerView.topAnchor, constant: 10),
-            saveButton.bottomAnchor.constraint(equalTo: footerView.bottomAnchor, constant: -10),
-            saveButton.leadingAnchor.constraint(equalTo: footerView.leadingAnchor, constant: 10),
-            saveButton.trailingAnchor.constraint(equalTo: footerView.trailingAnchor, constant: -10)
-        ])
+        saveButton.snp.makeConstraints { make in
+            make.edges.equalToSuperview().inset(10)
+        }
 
-        layoutIfNeeded()
+        self.addSubview(footerView)
+        footerView.snp.makeConstraints { make in
+            make.height.equalTo(50)
+            make.leading.trailing.equalTo(self.safeAreaLayoutGuide)
+        }
         
+        layoutIfNeeded()
         // createAccountButton의 하단 Constraint 설정
         bottomConstraint = footerView.bottomAnchor.constraint(equalTo: self.safeAreaLayoutGuide.bottomAnchor, constant: 15)
-        
         guard let bottomConstraint = bottomConstraint else {
             return
         }
-        
-        self.addSubview(footerView)
-        NSLayoutConstraint.activate([
-            footerView.leadingAnchor.constraint(equalTo: self.safeAreaLayoutGuide.leadingAnchor),
-            footerView.trailingAnchor.constraint(equalTo: self.safeAreaLayoutGuide.trailingAnchor),
-            bottomConstraint
-        ])
+        bottomConstraint.isActive = true
     }
     
     private func configureTableView() {
-        addInformationTableView.tableHeaderView = UIView(frame: .zero)
         addInformationTableView.separatorStyle = .singleLine
+        addInformationTableView.backgroundColor = .systemGray5
         addInformationTableView.register(SimpleInformationTableViewCell.self, forCellReuseIdentifier: SimpleInformationTableViewCell.reuseIdentifier)
         addInformationTableView.register(LabelTableViewCell.self, forCellReuseIdentifier: LabelTableViewCell.reuseIdentifier)
         addInformationTableView.register(TextViewTableViewCell.self, forCellReuseIdentifier: TextViewTableViewCell.reuseIdentifier)

--- a/Facebook/Facebook/Features/Profile/Views/AddInformationView.swift
+++ b/Facebook/Facebook/Features/Profile/Views/AddInformationView.swift
@@ -56,10 +56,8 @@ class AddInformationView: UIView {
             make.height.equalTo(50)
             make.leading.trailing.equalTo(self.safeAreaLayoutGuide)
         }
-        
-        layoutIfNeeded()
         // createAccountButton의 하단 Constraint 설정
-        bottomConstraint = footerView.bottomAnchor.constraint(equalTo: self.safeAreaLayoutGuide.bottomAnchor, constant: 15)
+        bottomConstraint = footerView.bottomAnchor.constraint(equalTo: self.safeAreaLayoutGuide.bottomAnchor)
         guard let bottomConstraint = bottomConstraint else {
             return
         }
@@ -69,6 +67,7 @@ class AddInformationView: UIView {
     private func configureTableView() {
         addInformationTableView.separatorStyle = .singleLine
         addInformationTableView.backgroundColor = .systemGray5
+        addInformationTableView.tableHeaderView = UIView(frame: .zero)
         addInformationTableView.register(SimpleInformationTableViewCell.self, forCellReuseIdentifier: SimpleInformationTableViewCell.reuseIdentifier)
         addInformationTableView.register(LabelTableViewCell.self, forCellReuseIdentifier: LabelTableViewCell.reuseIdentifier)
         addInformationTableView.register(TextViewTableViewCell.self, forCellReuseIdentifier: TextViewTableViewCell.reuseIdentifier)

--- a/Facebook/Facebook/Features/Profile/Views/ButtonTableViewCell.swift
+++ b/Facebook/Facebook/Features/Profile/Views/ButtonTableViewCell.swift
@@ -25,6 +25,7 @@ class ButtonTableViewCell: UITableViewCell {
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
+        self.frame.size.width = UIScreen.main.bounds.width // important for initial layout
     }
     
     required init?(coder: NSCoder) {

--- a/Facebook/Facebook/Features/Profile/Views/DateSelectTableViewCell.swift
+++ b/Facebook/Facebook/Features/Profile/Views/DateSelectTableViewCell.swift
@@ -55,6 +55,7 @@ class DateSelectTableViewCell: UITableViewCell {
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
+        self.frame.size.width = UIScreen.main.bounds.width // important for initial layout
     }
     
     required init?(coder: NSCoder) {

--- a/Facebook/Facebook/Features/Profile/Views/DetailInformationTableViewCell.swift
+++ b/Facebook/Facebook/Features/Profile/Views/DetailInformationTableViewCell.swift
@@ -130,66 +130,54 @@ class DetailInformationTableViewCell: UITableViewCell {
     private func setLayout() {
         switch self.cellStyle {
         case .style1:
-            self.contentView.addSubview(informationImage)
-            informationImage.translatesAutoresizingMaskIntoConstraints = false
-            NSLayoutConstraint.activate([
-                informationImage.heightAnchor.constraint(equalToConstant: 35),
-                informationImage.widthAnchor.constraint(equalToConstant: 35),
-                informationImage.centerYAnchor.constraint(equalTo: self.contentView.centerYAnchor),
-                informationImage.topAnchor.constraint(equalTo: self.contentView.topAnchor, constant: 10),
-                informationImage.bottomAnchor.constraint(equalTo: self.contentView.bottomAnchor, constant: -10),
-                informationImage.leadingAnchor.constraint(equalTo: self.contentView.leadingAnchor, constant: 15)
-            ])
+            contentView.addSubview(informationImage)
+            informationImage.snp.remakeConstraints { make in
+                make.height.width.equalTo(35)
+                make.top.bottom.equalTo(contentView).inset(10)
+                make.leading.equalTo(contentView).inset(15)
+            }
             
-            self.contentView.addSubview(labelStackView)
-            labelStackView.translatesAutoresizingMaskIntoConstraints = false
-            NSLayoutConstraint.activate([
-                labelStackView.centerYAnchor.constraint(equalTo: self.contentView.centerYAnchor),
-                labelStackView.leadingAnchor.constraint(equalTo: informationImage.trailingAnchor, constant: 15)
-            ])
+            contentView.addSubview(labelStackView)
+            labelStackView.snp.remakeConstraints { make in
+                make.centerY.equalTo(contentView)
+                make.leading.equalTo(informationImage.snp.trailing).inset(-15)
+            }
             
             labelStackView.addArrangedSubview(informationLabel)
             labelStackView.addArrangedSubview(descriptionLabel)
         case .style2:
-            self.contentView.addSubview(informationImage)
-            informationImage.translatesAutoresizingMaskIntoConstraints = false
-            NSLayoutConstraint.activate([
-                informationImage.heightAnchor.constraint(equalToConstant: 35),
-                informationImage.widthAnchor.constraint(equalToConstant: 35),
-                informationImage.topAnchor.constraint(equalTo: self.contentView.topAnchor, constant: 10),
-                informationImage.leadingAnchor.constraint(equalTo: self.contentView.leadingAnchor, constant: 15)
-            ])
+            contentView.addSubview(informationImage)
+            informationImage.snp.remakeConstraints { make in
+                make.height.width.equalTo(35)
+                make.top.equalTo(contentView).inset(CGFloat.standardTopMargin)
+                make.leading.equalTo(contentView).inset(CGFloat.standardLeadingMargin)
+            }
             
-            self.contentView.addSubview(labelStackView)
-            labelStackView.translatesAutoresizingMaskIntoConstraints = false
-            NSLayoutConstraint.activate([
-                labelStackView.centerYAnchor.constraint(equalTo: self.contentView.centerYAnchor),
-                labelStackView.topAnchor.constraint(equalTo: self.contentView.topAnchor, constant: 5),
-                labelStackView.bottomAnchor.constraint(equalTo: self.contentView.bottomAnchor, constant: -5),
-                labelStackView.leadingAnchor.constraint(equalTo: informationImage.trailingAnchor, constant: 15)
-            ])
+            contentView.addSubview(labelStackView)
+            labelStackView.snp.remakeConstraints { make in
+                make.centerY.equalTo(contentView)
+                make.top.bottom.equalTo(contentView).inset(5)
+                make.leading.equalTo(informationImage.snp.trailing).inset(-15)
+            }
             
             labelStackView.addArrangedSubview(informationLabel)
             labelStackView.addArrangedSubview(descriptionLabel)
             labelStackView.addArrangedSubview(privacyBoundLabel)
         case .style3:
-            self.contentView.addSubview(informationImage)
-            informationImage.translatesAutoresizingMaskIntoConstraints = false
-            NSLayoutConstraint.activate([
-                informationImage.heightAnchor.constraint(equalToConstant: 35),
-                informationImage.widthAnchor.constraint(equalToConstant: 35),
-                informationImage.topAnchor.constraint(equalTo: self.contentView.topAnchor, constant: 10),
-                informationImage.leadingAnchor.constraint(equalTo: self.contentView.leadingAnchor, constant: 15)
-            ])
+            contentView.addSubview(informationImage)
+            informationImage.snp.remakeConstraints { make in
+                make.height.width.equalTo(35)
+                make.top.equalTo(contentView).inset(CGFloat.standardTopMargin)
+                make.leading.equalTo(contentView).inset(CGFloat.standardLeadingMargin)
+            }
             
-            self.contentView.addSubview(labelStackView)
-            labelStackView.translatesAutoresizingMaskIntoConstraints = false
-            NSLayoutConstraint.activate([
-                labelStackView.centerYAnchor.constraint(equalTo: self.contentView.centerYAnchor),
-                labelStackView.topAnchor.constraint(equalTo: self.contentView.topAnchor, constant: 5),
-                labelStackView.bottomAnchor.constraint(equalTo: self.contentView.bottomAnchor, constant: -5),
-                labelStackView.leadingAnchor.constraint(equalTo: informationImage.trailingAnchor, constant: 15)
-            ])
+            contentView.addSubview(labelStackView)
+            labelStackView.snp.remakeConstraints { make in
+                make.centerY.equalTo(contentView)
+                make.top.bottom.equalTo(contentView).inset(5)
+                make.leading.equalTo(informationImage.snp.trailing).inset(-15)
+            }
+
             
             labelStackView.addArrangedSubview(informationLabel)
             labelStackView.addArrangedSubview(timeLabel)
@@ -197,46 +185,37 @@ class DetailInformationTableViewCell: UITableViewCell {
             labelStackView.addArrangedSubview(descriptionLabel)
 
             
-            self.contentView.addSubview(editButton)
-            editButton.translatesAutoresizingMaskIntoConstraints = false
-            NSLayoutConstraint.activate([
-                editButton.heightAnchor.constraint(equalToConstant: 30),
-                editButton.widthAnchor.constraint(equalToConstant: 30),
-                editButton.topAnchor.constraint(equalTo: self.contentView.topAnchor, constant: 10),
-                editButton.trailingAnchor.constraint(equalTo: self.contentView.trailingAnchor, constant: -10)
-            ])
+            contentView.addSubview(editButton)
+            editButton.snp.remakeConstraints { make in
+                make.height.width.equalTo(30)
+                make.top.equalTo(contentView).inset(CGFloat.standardTopMargin)
+                make.trailing.equalTo(contentView).inset(15)
+            }
         case .style4:
-            self.contentView.addSubview(informationImage)
-            informationImage.translatesAutoresizingMaskIntoConstraints = false
-            NSLayoutConstraint.activate([
-                informationImage.heightAnchor.constraint(equalToConstant: 20),
-                informationImage.widthAnchor.constraint(equalToConstant: 20),
-                informationImage.centerYAnchor.constraint(equalTo: self.contentView.centerYAnchor),
-                informationImage.topAnchor.constraint(equalTo: self.contentView.topAnchor, constant: 15),
-                informationImage.bottomAnchor.constraint(equalTo: self.contentView.bottomAnchor, constant: -15),
-                informationImage.leadingAnchor.constraint(equalTo: self.contentView.leadingAnchor, constant: 15)
-            ])
+            contentView.addSubview(informationImage)
+            informationImage.snp.remakeConstraints { make in
+                make.centerY.equalTo(contentView)
+                make.height.width.equalTo(20)
+                make.top.bottom.leading.equalTo(contentView).inset(15)
+            }
             
-            self.contentView.addSubview(labelStackView)
-            labelStackView.translatesAutoresizingMaskIntoConstraints = false
-            NSLayoutConstraint.activate([
-                labelStackView.heightAnchor.constraint(equalToConstant: 20),
-                labelStackView.centerYAnchor.constraint(equalTo: self.contentView.centerYAnchor),
-                labelStackView.topAnchor.constraint(equalTo: self.contentView.topAnchor, constant: 5),
-                labelStackView.bottomAnchor.constraint(equalTo: self.contentView.bottomAnchor, constant: -5),
-                labelStackView.leadingAnchor.constraint(equalTo: informationImage.trailingAnchor, constant: 15)
-            ])
+            
+            contentView.addSubview(labelStackView)
+            labelStackView.snp.remakeConstraints { make in
+                make.centerY.equalTo(contentView)
+                make.height.equalTo(20)
+                make.top.bottom.equalTo(contentView).inset(5)
+                make.leading.equalTo(informationImage.snp.trailing).inset(-15)
+            }
             
             labelStackView.addArrangedSubview(informationLabel)
             
-            self.contentView.addSubview(editButton)
-            editButton.translatesAutoresizingMaskIntoConstraints = false
-            NSLayoutConstraint.activate([
-                editButton.heightAnchor.constraint(equalToConstant: 30),
-                editButton.widthAnchor.constraint(equalToConstant: 30),
-                editButton.centerYAnchor.constraint(equalTo: self.contentView.centerYAnchor),
-                editButton.trailingAnchor.constraint(equalTo: self.contentView.trailingAnchor, constant: -15)
-            ])
+            contentView.addSubview(editButton)
+            editButton.snp.remakeConstraints { make in
+                make.height.width.equalTo(30)
+                make.centerY.equalTo(contentView)
+                make.trailing.equalTo(contentView).inset(15)
+            }
         }
     }
     

--- a/Facebook/Facebook/Features/Profile/Views/DetailInformationTableViewCell.swift
+++ b/Facebook/Facebook/Features/Profile/Views/DetailInformationTableViewCell.swift
@@ -204,7 +204,6 @@ class DetailInformationTableViewCell: UITableViewCell {
             labelStackView.snp.remakeConstraints { make in
                 make.centerY.equalTo(contentView)
                 make.height.equalTo(20)
-                make.top.bottom.equalTo(contentView).inset(5)
                 make.leading.equalTo(informationImage.snp.trailing).inset(-15)
             }
             

--- a/Facebook/Facebook/Features/Profile/Views/DetailInformationTableViewCell.swift
+++ b/Facebook/Facebook/Features/Profile/Views/DetailInformationTableViewCell.swift
@@ -28,6 +28,7 @@ class DetailInformationTableViewCell: UITableViewCell {
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
+        self.frame.size.width = UIScreen.main.bounds.width // important for initial layout
     }
     
     required init?(coder: NSCoder) {

--- a/Facebook/Facebook/Features/Profile/Views/EditDetailInformationView.swift
+++ b/Facebook/Facebook/Features/Profile/Views/EditDetailInformationView.swift
@@ -50,28 +50,25 @@ class EditDetailInformationView: UIView {
     private func setLayoutforView() {
         self.addSubview(editDetailInformationTableView)
         
-        editDetailInformationTableView.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            editDetailInformationTableView.topAnchor.constraint(equalTo: self.safeAreaLayoutGuide.topAnchor),
-            editDetailInformationTableView.bottomAnchor.constraint(equalTo: self.safeAreaLayoutGuide.bottomAnchor),
-            editDetailInformationTableView.leadingAnchor.constraint(equalTo: self.safeAreaLayoutGuide.leadingAnchor),
-            editDetailInformationTableView.trailingAnchor.constraint(equalTo: self.safeAreaLayoutGuide.trailingAnchor)
-        ])
+        editDetailInformationTableView.snp.makeConstraints { make in
+            make.edges.equalTo(self.safeAreaLayoutGuide)
+        }
         
-        headerView.frame = CGRect(x: 0, y: 0, width: editDetailInformationTableView.frame.width, height: 70)
+        headerView.frame = CGRect(x: 0, y: 0, width: editDetailInformationTableView.frame.width, height: 75)
+        headerView.heightAnchor.constraint(equalToConstant: 75).isActive = true
         
         headerView.addSubview(titleLabel)
         headerView.addSubview(subTitleLabel)
-        NSLayoutConstraint.activate([
-            headerView.heightAnchor.constraint(equalToConstant: 70),
-            titleLabel.heightAnchor.constraint(equalToConstant: 20),
-            titleLabel.topAnchor.constraint(equalTo: headerView.topAnchor, constant: 15),
-            titleLabel.leadingAnchor.constraint(equalTo: headerView.leadingAnchor, constant: 15),
-            subTitleLabel.heightAnchor.constraint(equalToConstant: 20),
-            subTitleLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 5),
-            subTitleLabel.leadingAnchor.constraint(equalTo: headerView.leadingAnchor, constant: 15),
-            subTitleLabel.bottomAnchor.constraint(equalTo: headerView.bottomAnchor, constant: -15)
-        ])
+        titleLabel.snp.makeConstraints { make in
+            make.height.equalTo(20)
+            make.top.leading.equalTo(headerView).inset(15)
+        }
+        subTitleLabel.snp.makeConstraints { make in
+            make.height.equalTo(20)
+            make.top.equalTo(titleLabel.snp.bottom).inset(-5)
+            make.leading.equalTo(headerView).inset(15)
+            make.bottom.equalTo(headerView).inset(15)
+        }
     }
     
     private func configureTableView() {

--- a/Facebook/Facebook/Features/Profile/Views/LabelTableViewCell.swift
+++ b/Facebook/Facebook/Features/Profile/Views/LabelTableViewCell.swift
@@ -24,6 +24,7 @@ class LabelTableViewCell: UITableViewCell {
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
+        self.frame.size.width = UIScreen.main.bounds.width // important for initial layout
     }
     
     required init?(coder: NSCoder) {

--- a/Facebook/Facebook/Features/Profile/Views/SimpleInformationTableViewCell.swift
+++ b/Facebook/Facebook/Features/Profile/Views/SimpleInformationTableViewCell.swift
@@ -98,66 +98,59 @@ class SimpleInformationTableViewCell: UITableViewCell {
         case .style1, .style2:
             addSubview(informationImage)
             informationImage.translatesAutoresizingMaskIntoConstraints = false
-            NSLayoutConstraint.activate([
-                informationImage.heightAnchor.constraint(equalToConstant: 20),
-                informationImage.widthAnchor.constraint(equalToConstant: 20),
-                informationImage.centerYAnchor.constraint(equalTo: self.centerYAnchor),
-                informationImage.topAnchor.constraint(equalTo: self.topAnchor, constant: 10),
-                informationImage.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -10),
-                informationImage.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 15)
-            ])
+            informationImage.snp.remakeConstraints { make in
+                make.height.width.equalTo(20)
+                make.centerY.equalTo(self)
+                make.top.bottom.equalTo(self).inset(CGFloat.standardTopMargin)
+                make.leading.equalTo(self).inset(CGFloat.standardLeadingMargin)
+            }
             
             addSubview(informationLabel)
             informationLabel.translatesAutoresizingMaskIntoConstraints = false
-            NSLayoutConstraint.activate([
-                informationLabel.centerYAnchor.constraint(equalTo: self.centerYAnchor),
-                informationLabel.leadingAnchor.constraint(equalTo: informationImage.trailingAnchor, constant: 15)
-            ])
+            informationLabel.snp.remakeConstraints { make in
+                make.centerY.equalTo(self)
+                make.leading.equalTo(informationImage.snp.trailing).inset(CGFloat.standardTrailingMargin)
+            }
         case .style3:
             addSubview(informationImage)
             informationImage.translatesAutoresizingMaskIntoConstraints = false
-            NSLayoutConstraint.activate([
-                informationImage.heightAnchor.constraint(equalToConstant: 35),
-                informationImage.widthAnchor.constraint(equalToConstant: 35),
-                informationImage.centerYAnchor.constraint(equalTo: self.centerYAnchor),
-                informationImage.topAnchor.constraint(equalTo: self.topAnchor, constant: 10),
-                informationImage.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -10),
-                informationImage.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 15)
-            ])
+            informationImage.snp.remakeConstraints { make in
+                make.height.width.equalTo(35)
+                make.centerY.equalTo(self)
+                make.top.bottom.equalTo(self).inset(CGFloat.standardTopMargin)
+                make.leading.equalTo(self).inset(CGFloat.standardLeadingMargin)
+            }
             
             addSubview(informationLabel)
             informationLabel.translatesAutoresizingMaskIntoConstraints = false
-            NSLayoutConstraint.activate([
-                informationLabel.centerYAnchor.constraint(equalTo: self.centerYAnchor),
-                informationLabel.leadingAnchor.constraint(equalTo: informationImage.trailingAnchor, constant: 20)
-            ])
+            informationLabel.snp.remakeConstraints { make in
+                make.centerY.equalTo(self)
+                make.leading.equalTo(informationImage.snp.trailing).inset(CGFloat.standardTrailingMargin)
+            }
         case .style4:
             self.contentView.addSubview(informationImage)
             informationImage.translatesAutoresizingMaskIntoConstraints = false
-            NSLayoutConstraint.activate([
-                informationImage.heightAnchor.constraint(equalToConstant: 35),
-                informationImage.widthAnchor.constraint(equalToConstant: 35),
-                informationImage.centerYAnchor.constraint(equalTo: self.contentView.centerYAnchor),
-                informationImage.topAnchor.constraint(equalTo: self.contentView.topAnchor, constant: 10),
-                informationImage.bottomAnchor.constraint(equalTo: self.contentView.bottomAnchor, constant: -10),
-                informationImage.leadingAnchor.constraint(equalTo: self.contentView.leadingAnchor, constant: 15)
-            ])
+            informationImage.snp.remakeConstraints { make in
+                make.height.width.equalTo(35)
+                make.centerY.equalTo(self)
+                make.top.bottom.equalTo(self).inset(CGFloat.standardTopMargin)
+                make.leading.equalTo(self).inset(CGFloat.standardLeadingMargin)
+            }
             
             self.contentView.addSubview(informationLabel)
             informationLabel.translatesAutoresizingMaskIntoConstraints = false
-            NSLayoutConstraint.activate([
-                informationLabel.centerYAnchor.constraint(equalTo: self.contentView.centerYAnchor),
-                informationLabel.leadingAnchor.constraint(equalTo: informationImage.trailingAnchor, constant: 20)
-            ])
+            informationLabel.snp.remakeConstraints { make in
+                make.centerY.equalTo(self)
+                make.leading.equalTo(informationImage.snp.trailing).inset(CGFloat.standardTrailingMargin)
+            }
             
             self.contentView.addSubview(deleteButton)
             deleteButton.translatesAutoresizingMaskIntoConstraints = false
-            NSLayoutConstraint.activate([
-                deleteButton.heightAnchor.constraint(equalToConstant: 20),
-                deleteButton.widthAnchor.constraint(equalToConstant: 20),
-                deleteButton.centerYAnchor.constraint(equalTo: self.contentView.centerYAnchor),
-                deleteButton.trailingAnchor.constraint(equalTo: self.contentView.trailingAnchor, constant: -15)
-            ])
+            deleteButton.snp.remakeConstraints { make in
+                make.height.width.equalTo(35)
+                make.centerY.equalTo(self)
+                make.trailing.equalTo(self).inset(CGFloat.standardLeadingMargin)
+            }
             deleteButton.isHidden = true
         }
     }

--- a/Facebook/Facebook/Features/Profile/Views/SimpleInformationTableViewCell.swift
+++ b/Facebook/Facebook/Features/Profile/Views/SimpleInformationTableViewCell.swift
@@ -95,6 +95,7 @@ class SimpleInformationTableViewCell: UITableViewCell {
     }
     
     private func setLayout() {
+        
         switch self.cellStyle {
         case .style1, .style2:
             contentView.addSubview(informationImage)
@@ -125,10 +126,6 @@ class SimpleInformationTableViewCell: UITableViewCell {
                 make.leading.equalTo(informationImage.snp.trailing).inset(CGFloat.standardTrailingMargin)
             }
         case .style4:
-            contentView.snp.makeConstraints { make in
-                make.height.equalTo(55)
-            }
-            
             contentView.addSubview(informationImage)
             informationImage.snp.remakeConstraints { make in
                 make.height.width.equalTo(35)

--- a/Facebook/Facebook/Features/Profile/Views/SimpleInformationTableViewCell.swift
+++ b/Facebook/Facebook/Features/Profile/Views/SimpleInformationTableViewCell.swift
@@ -28,6 +28,7 @@ class SimpleInformationTableViewCell: UITableViewCell {
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
+        self.frame.size.width = UIScreen.main.bounds.width // important for initial layout
     }
     
     required init?(coder: NSCoder) {
@@ -96,60 +97,57 @@ class SimpleInformationTableViewCell: UITableViewCell {
     private func setLayout() {
         switch self.cellStyle {
         case .style1, .style2:
-            addSubview(informationImage)
-            informationImage.translatesAutoresizingMaskIntoConstraints = false
+            contentView.addSubview(informationImage)
             informationImage.snp.remakeConstraints { make in
                 make.height.width.equalTo(20)
-                make.centerY.equalTo(self)
-                make.top.bottom.equalTo(self).inset(CGFloat.standardTopMargin)
-                make.leading.equalTo(self).inset(CGFloat.standardLeadingMargin)
+                make.centerY.equalTo(contentView)
+                make.top.bottom.equalTo(contentView).inset(10)
+                make.leading.equalTo(contentView).inset(CGFloat.standardLeadingMargin)
             }
             
-            addSubview(informationLabel)
-            informationLabel.translatesAutoresizingMaskIntoConstraints = false
+            contentView.addSubview(informationLabel)
             informationLabel.snp.remakeConstraints { make in
-                make.centerY.equalTo(self)
+                make.centerY.equalTo(contentView)
                 make.leading.equalTo(informationImage.snp.trailing).inset(CGFloat.standardTrailingMargin)
             }
         case .style3:
-            addSubview(informationImage)
-            informationImage.translatesAutoresizingMaskIntoConstraints = false
+            contentView.addSubview(informationImage)
             informationImage.snp.remakeConstraints { make in
                 make.height.width.equalTo(35)
-                make.centerY.equalTo(self)
-                make.top.bottom.equalTo(self).inset(CGFloat.standardTopMargin)
-                make.leading.equalTo(self).inset(CGFloat.standardLeadingMargin)
+                make.centerY.equalTo(contentView)
+                make.top.bottom.equalTo(contentView).inset(10)
+                make.leading.equalTo(contentView).inset(CGFloat.standardLeadingMargin)
             }
             
-            addSubview(informationLabel)
-            informationLabel.translatesAutoresizingMaskIntoConstraints = false
+            contentView.addSubview(informationLabel)
             informationLabel.snp.remakeConstraints { make in
-                make.centerY.equalTo(self)
+                make.centerY.equalTo(contentView)
                 make.leading.equalTo(informationImage.snp.trailing).inset(CGFloat.standardTrailingMargin)
             }
         case .style4:
-            self.contentView.addSubview(informationImage)
-            informationImage.translatesAutoresizingMaskIntoConstraints = false
-            informationImage.snp.remakeConstraints { make in
-                make.height.width.equalTo(35)
-                make.centerY.equalTo(self)
-                make.top.bottom.equalTo(self).inset(CGFloat.standardTopMargin)
-                make.leading.equalTo(self).inset(CGFloat.standardLeadingMargin)
+            contentView.snp.makeConstraints { make in
+                make.height.equalTo(55)
             }
             
-            self.contentView.addSubview(informationLabel)
-            informationLabel.translatesAutoresizingMaskIntoConstraints = false
+            contentView.addSubview(informationImage)
+            informationImage.snp.remakeConstraints { make in
+                make.height.width.equalTo(35)
+                make.centerY.equalTo(contentView)
+                make.top.bottom.equalTo(contentView).inset(10)
+                make.leading.equalTo(contentView).inset(CGFloat.standardLeadingMargin)
+            }
+            
+            contentView.addSubview(informationLabel)
             informationLabel.snp.remakeConstraints { make in
-                make.centerY.equalTo(self)
+                make.centerY.equalTo(contentView)
                 make.leading.equalTo(informationImage.snp.trailing).inset(CGFloat.standardTrailingMargin)
             }
             
-            self.contentView.addSubview(deleteButton)
-            deleteButton.translatesAutoresizingMaskIntoConstraints = false
+            contentView.addSubview(deleteButton)
             deleteButton.snp.remakeConstraints { make in
                 make.height.width.equalTo(35)
-                make.centerY.equalTo(self)
-                make.trailing.equalTo(self).inset(CGFloat.standardLeadingMargin)
+                make.centerY.equalTo(contentView)
+                make.trailing.equalTo(contentView).inset(CGFloat.standardLeadingMargin)
             }
             deleteButton.isHidden = true
         }

--- a/Facebook/Facebook/Features/Profile/Views/TextViewTableViewCell.swift
+++ b/Facebook/Facebook/Features/Profile/Views/TextViewTableViewCell.swift
@@ -18,6 +18,7 @@ class TextViewTableViewCell: UITableViewCell {
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
+        self.frame.size.width = UIScreen.main.bounds.width // important for initial layout
     }
     
     required init?(coder: NSCoder) {


### PR DESCRIPTION
섹션 헤더 내부에 체크박스가 있고,
체크박스를 탭할 때마다 섹션 헤더의 UI를 변경시키도록 `bind`를 해두셨기 때문에
체크박스를 탭할 때마다 `viewForHeaderInSection`가 호출됩니다.

그런데 체크박스를 생성하는 코드가 `viewForHeaderInSection` 내부에 있어서
체크박스를 탭할 때마다 체크되어있는 상태의 체크박스가 매번 생성되면서 이미지가 안바뀌는 것처럼 보이는 문제입니다.

체크박스 바인딩 코드를 외부에서 딱 한번만 실행되도록 옮기고
체크박스도 매번 새롭게 initialize되지 않도록 외부로 빼주면 해결됩니다!

그런데 이밖에도 프로필쪽에서 오토레이아웃 Conflict가 상당히 많이 발생하고 있어서
master 브랜치에 머지하기 전에 해결해주시면 감사하겠습니다.

[WTF AutoLayout](https://www.wtfautolayout.com/) 활용하시면 어디에서 문제가 발생한것인지 쉽게 알 수 있습니다.
