### PR TITLE
검색 버그 수정

### DIFF
--- a/Facebook/Facebook/Common/ViewModels/PaginationViewModel.swift
+++ b/Facebook/Facebook/Common/ViewModels/PaginationViewModel.swift
@@ -39,6 +39,7 @@ class PaginationViewModel<DataModel: Codable> {
     let isRefreshing = BehaviorRelay<Bool>(value: false)
     let refreshComplete = PublishRelay<Bool>()
     let hasNextObservable = BehaviorRelay<Bool>(value: false)
+    var loadOnInit: Bool { true }
     
     private var isFetchingData: Bool {
         return isLoading.value || isRefreshing.value
@@ -47,7 +48,9 @@ class PaginationViewModel<DataModel: Codable> {
     init(endpoint: Endpoint) {
         self.endpoint = endpoint
         self.bind()
-        self.loadMore()
+        if loadOnInit {
+            self.loadMore()
+        }
     }
     
     func loadMore() {

--- a/Facebook/Facebook/Features/Search/Controllers/SearchViewController.swift
+++ b/Facebook/Facebook/Features/Search/Controllers/SearchViewController.swift
@@ -13,7 +13,7 @@ import RxKeyboard
 class SearchViewController: UIViewController {
     private let searchBar = UISearchBar()
     private let disposeBag = DisposeBag()
-    private let viewModel = SearchPaginationViewModel(endpoint: .search(query: ""))
+    private let viewModel = SearchPaginationViewModel(endpoint: .search(query: "$"))
     
     override func loadView() {
         view = SearchView()

--- a/Facebook/Facebook/Features/Search/Controllers/SearchViewController.swift
+++ b/Facebook/Facebook/Features/Search/Controllers/SearchViewController.swift
@@ -13,7 +13,7 @@ import RxKeyboard
 class SearchViewController: UIViewController {
     private let searchBar = UISearchBar()
     private let disposeBag = DisposeBag()
-    private let viewModel = SearchPaginationViewModel(endpoint: .search(query: "$"))
+    private let viewModel = SearchPaginationViewModel(endpoint: .search(query: ""))
     
     override func loadView() {
         view = SearchView()

--- a/Facebook/Facebook/Features/Search/ViewModels/SearchPaginationViewModel.swift
+++ b/Facebook/Facebook/Features/Search/ViewModels/SearchPaginationViewModel.swift
@@ -10,6 +10,7 @@ import Foundation
 class SearchPaginationViewModel: PaginationViewModel<User> {
     
     var query: String?
+    override var loadOnInit: Bool { false }
     
     func setQuery(_ query: String) {
         self.query = query


### PR DESCRIPTION
머지하는 과정에서 PaginationViewModel을 처음 초기화할때 검색어를 ""로 해두었는데, 이것때문에 서버에서 String 형 응답이 와서 Observable이 terminate되는 문제였습니다.

`SearchPaginationViewModel`은 초기화할 때 API 요청을 보내지 않도록 변경하였습니다.