### PR TITLE
bottom sheet menu 구현

### DIFF
--- a/Facebook/Facebook/Features/Profile/Controllers/EditProfileViewController.swift
+++ b/Facebook/Facebook/Features/Profile/Controllers/EditProfileViewController.swift
@@ -311,30 +311,21 @@ class EditProfileViewController<View: EditProfileView>: UIViewController, UITabl
 extension EditProfileViewController {
     //자기 소개가 이미 있을 때 자기 소개 관련 메뉴(alertsheet형식) present
     func showAlertSelfIntroMenu() {
-        let alertMenu = UIAlertController(title: "자기 소개", message: "", preferredStyle: .actionSheet)
-        
-        let editSelfIntroAction = UIAlertAction(title: "소개 수정", style: .default, handler: { action in
+        let menuList = [ Menu(image: UIImage(systemName: "pencil.and.outline") ?? UIImage(),
+                              text: "소개 수정", action: {
             let addSelfIntroViewController = AddSelfIntroViewController()
             let navigationController = UINavigationController(rootViewController: addSelfIntroViewController)
             navigationController.modalPresentationStyle = .fullScreen
             self.present(navigationController, animated: true, completion: nil)
-        })
-        editSelfIntroAction.setValue(0, forKey: "titleTextAlignment")
-        editSelfIntroAction.setValue(UIImage(systemName: "pencil.circle")!, forKey: "image")
-        
-        let deleteSelfIntroAction = UIAlertAction(title: "소개 삭제", style: .default, handler: { action in
+        }),
+                         Menu(image: UIImage(systemName: "trash.fill") ?? UIImage(),
+                              text: "소개 삭제", action: {
             self.deleteSelfIntro()
-        })
-        deleteSelfIntroAction.setValue(0, forKey: "titleTextAlignment")
-        deleteSelfIntroAction.setValue(UIImage(systemName: "trash.circle")!, forKey: "image")
+        })]
         
-        let cancelAction = UIAlertAction(title: "취소", style: .default, handler: nil)
-        
-        alertMenu.addAction(editSelfIntroAction)
-        alertMenu.addAction(deleteSelfIntroAction)
-        alertMenu.addAction(cancelAction)
-        
-        self.present(alertMenu, animated: true, completion: nil)
+        let bottomSheetVC = BottomSheetViewController(menuList: menuList)
+        bottomSheetVC.modalPresentationStyle = .overFullScreen
+        self.present(bottomSheetVC, animated: false, completion: nil)
     }
     
     func deleteSelfIntro() {
@@ -353,36 +344,20 @@ extension EditProfileViewController {
     }
     
     func showAlertImageMenu() {
-        let alertMenu = UIAlertController(title: self.imageType == "profile_image" ?
-                                          "프로필 사진 수정" : "커버 사진 수정",
-                                          message: "",
-                                          preferredStyle: .actionSheet)
+        let menuList = [ Menu(image: UIImage(systemName: "photo.on.rectangle.angled") ?? UIImage(),
+                              text: self.imageType == "profile_image" ?
+                              "프로필 사진 변경" : "커버 사진 변경", action: {
+            self.presentPicker()
+        }),
+                         Menu(image: UIImage(systemName: "trash.fill") ?? UIImage(),
+                              text: self.imageType == "profile_image" ?
+                              "프로필 사진 삭제" : "커버 사진 삭제", action: {
+            self.deleteImage()
+        })]
         
-        let editSelfIntroAction = UIAlertAction(title: self.imageType == "profile_image" ?
-                                                "프로필 사진 변경" : "커버 사진 변경",
-                                                style: .default,
-                                                handler: { action in
-                                                    self.presentPicker()
-                                                })
-        editSelfIntroAction.setValue(0, forKey: "titleTextAlignment")
-        editSelfIntroAction.setValue(UIImage(systemName: "photo.on.rectangle.angled")!, forKey: "image")
-        
-        let deleteSelfIntroAction = UIAlertAction(title: self.imageType == "profile_image" ?
-                                                  "프로필 사진 삭제" : "커버 사진 삭제",
-                                                  style: .default,
-                                                  handler: { action in
-                                                      self.deleteImage()
-                                                  })
-        deleteSelfIntroAction.setValue(0, forKey: "titleTextAlignment")
-        deleteSelfIntroAction.setValue(UIImage(systemName: "trash.circle")!, forKey: "image")
-        
-        let cancelAction = UIAlertAction(title: "취소", style: .default, handler: nil)
-        
-        alertMenu.addAction(editSelfIntroAction)
-        alertMenu.addAction(deleteSelfIntroAction)
-        alertMenu.addAction(cancelAction)
-        
-        self.present(alertMenu, animated: true, completion: nil)
+        let bottomSheetVC = BottomSheetViewController(menuList: menuList)
+        bottomSheetVC.modalPresentationStyle = .overFullScreen
+        self.present(bottomSheetVC, animated: false, completion: nil)
     }
     
     func deleteImage() {

--- a/Facebook/Facebook/Features/Profile/Controllers/ProfileTabViewController.swift
+++ b/Facebook/Facebook/Features/Profile/Controllers/ProfileTabViewController.swift
@@ -432,80 +432,49 @@ class ProfileTabViewController: BaseTabViewController<ProfileTabView>, UITableVi
 extension ProfileTabViewController {
     //자기 소개가 이미 있을 때 자기 소개 관련 메뉴(alertsheet형식) present
     func showAlertSelfIntroMenu() {
-        let alertMenu = UIAlertController(title: "자기 소개", message: "", preferredStyle: .actionSheet)
-        
-        let editSelfIntroAction = UIAlertAction(title: "소개 수정", style: .default, handler: { action in
+        let menuList = [ Menu(image: UIImage(systemName: "pencil.and.outline") ?? UIImage(),
+                              text: "소개 수정", action: {
             let addSelfIntroViewController = AddSelfIntroViewController()
             let navigationController = UINavigationController(rootViewController: addSelfIntroViewController)
             navigationController.modalPresentationStyle = .fullScreen
             self.present(navigationController, animated: true, completion: nil)
-        })
-        editSelfIntroAction.setValue(0, forKey: "titleTextAlignment")
-        editSelfIntroAction.setValue(UIImage(systemName: "pencil.circle")!, forKey: "image")
-        
-        let deleteSelfIntroAction = UIAlertAction(title: "소개 삭제", style: .default, handler: { action in
+        }),
+                         Menu(image: UIImage(systemName: "trash.fill") ?? UIImage(),
+                              text: "소개 삭제", action: {
             self.deleteSelfIntro()
-        })
-        deleteSelfIntroAction.setValue(0, forKey: "titleTextAlignment")
-        deleteSelfIntroAction.setValue(UIImage(systemName: "trash.circle")!, forKey: "image")
+        })]
         
-        let cancelAction = UIAlertAction(title: "취소", style: .default, handler: nil)
-        
-        alertMenu.addAction(editSelfIntroAction)
-        alertMenu.addAction(deleteSelfIntroAction)
-        alertMenu.addAction(cancelAction)
-        
-        self.present(alertMenu, animated: true, completion: nil)
+        let bottomSheetVC = BottomSheetViewController(menuList: menuList)
+        bottomSheetVC.modalPresentationStyle = .overFullScreen
+        self.present(bottomSheetVC, animated: false, completion: nil)
     }
     
     func showAlertImageMenu() {
-        let alertMenu = UIAlertController(title: self.imageType == "profile_image" ?
-                                          "프로필 사진 수정" : "커버 사진 수정",
-                                          message: "",
-                                          preferredStyle: .actionSheet)
+        let menuList = [ Menu(image: UIImage(systemName: "photo.on.rectangle.angled") ?? UIImage(),
+                              text: self.imageType == "profile_image" ?
+                              "프로필 사진 변경" : "커버 사진 변경", action: {
+            self.presentPicker()
+        }),
+                         Menu(image: UIImage(systemName: "trash.fill") ?? UIImage(),
+                              text: self.imageType == "profile_image" ?
+                              "프로필 사진 삭제" : "커버 사진 삭제", action: {
+            self.deleteImage()
+        })]
         
-        let editSelfIntroAction = UIAlertAction(title: self.imageType == "profile_image" ?
-                                                "프로필 사진 변경" : "커버 사진 변경",
-                                                style: .default,
-                                                handler: { action in
-                                                    self.presentPicker()
-                                                })
-        editSelfIntroAction.setValue(0, forKey: "titleTextAlignment")
-        editSelfIntroAction.setValue(UIImage(systemName: "photo.on.rectangle.angled")!, forKey: "image")
-        
-        let deleteSelfIntroAction = UIAlertAction(title: self.imageType == "profile_image" ?
-                                                  "프로필 사진 삭제" : "커버 사진 삭제",
-                                                  style: .default,
-                                                  handler: { action in
-                                                      self.deleteImage()
-                                                  })
-        deleteSelfIntroAction.setValue(0, forKey: "titleTextAlignment")
-        deleteSelfIntroAction.setValue(UIImage(systemName: "trash.circle")!, forKey: "image")
-        
-        let cancelAction = UIAlertAction(title: "취소", style: .default, handler: nil)
-        
-        alertMenu.addAction(editSelfIntroAction)
-        alertMenu.addAction(deleteSelfIntroAction)
-        alertMenu.addAction(cancelAction)
-        
-        self.present(alertMenu, animated: true, completion: nil)
+        let bottomSheetVC = BottomSheetViewController(menuList: menuList)
+        bottomSheetVC.modalPresentationStyle = .overFullScreen
+        self.present(bottomSheetVC, animated: false, completion: nil)
     }
     
     func showAlertFriendMenu() {
-        let alertMenu = UIAlertController(title: "친구 관리", message: "", preferredStyle: .actionSheet)
-        
-        let deleteFriendAction = UIAlertAction(title: "친구 끊기", style: .default, handler: { action in
+        let menuList = [ Menu(image: UIImage(systemName: "person.fill.xmark") ?? UIImage(),
+                              text: "친구 끊기", action: {
             self.deleleFriend()
-        })
-        deleteFriendAction.setValue(0, forKey: "titleTextAlignment")
-        deleteFriendAction.setValue(UIImage(systemName: "person.fill.xmark")!, forKey: "image")
+        })]
         
-        let cancelAction = UIAlertAction(title: "취소", style: .default, handler: nil)
-        
-        alertMenu.addAction(deleteFriendAction)
-        alertMenu.addAction(cancelAction)
-        
-        self.present(alertMenu, animated: true, completion: nil)
+        let bottomSheetVC = BottomSheetViewController(menuList: menuList)
+        bottomSheetVC.modalPresentationStyle = .overFullScreen
+        self.present(bottomSheetVC, animated: false, completion: nil)
     }
 }
 


### PR DESCRIPTION
기존에 action sheet 형식으로 구현했던 프로필, 커버 사진 수정 메뉴와 자기소개 수정 메뉴를 bottom sheet menu 형식으로 구현했습니다.
![Simulator Screen Shot - iPhone 12 Pro - 2022-01-24 at 20 26 43](https://user-images.githubusercontent.com/47500248/150774823-db9ca734-bd7e-4ca1-9104-14b86e981e26.png)
기존 action sheet 형식

![Simulator Screen Shot - iPhone 12 Pro - 2022-01-24 at 20 24 32](https://user-images.githubusercontent.com/47500248/150774737-b431088e-6ee8-4dc4-b754-12dd22cbd4f7.png)
바꾼 bottom sheet menu 형식
