### PR TITLE
Github Actions iOS 15.0 -> 15.2

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Start Xcode Build
-      run: xcodebuild clean -project Facebook/Facebook.xcodeproj -scheme Facebook -destination 'platform=iOS Simulator,name=iPhone 11 Pro,OS=15.0'
+      run: xcodebuild clean -project Facebook/Facebook.xcodeproj -scheme Facebook -destination 'platform=iOS Simulator,name=iPhone 11 Pro,OS=15.2'
   
   SwiftLint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Github Actions 시뮬레이터 버전 업그레이드에 따른 빌드 실패를 해결합니다.