### PR TITLE
메모리 누수 버그 수정

### DIFF
--- a/Facebook/Facebook/Features/PostDetail/Controllers/SubPostsViewController.swift
+++ b/Facebook/Facebook/Features/PostDetail/Controllers/SubPostsViewController.swift
@@ -96,7 +96,7 @@ class SubPostsViewController: UIViewController {
         
         /// Subposts ~ 테이블뷰 바인딩
         subpostsDataSource
-            .bind(to: tableView.rx.items(cellIdentifier: SubPostCell.reuseIdentifier, cellType: SubPostCell.self)) { row, post, cell in
+            .bind(to: tableView.rx.items(cellIdentifier: SubPostCell.reuseIdentifier, cellType: SubPostCell.self)) { [weak self] row, post, cell in
                 cell.configure(with: post)
 
                 // 좋아요 버튼 바인딩


### PR DESCRIPTION
영상 찍는데 이상한 버그가 간헐적으로 발생해서 열심히 디버깅을 하다가
아래처럼 작성하면 메모리 누수가 발생한다는 충격적인 사실을 알게 되었습니다. (저만 몰랐나요?)

```swift
dataSource.bind { row, data, cell in
    cell.rx.bind { [weak self]  // 여기서 self에 대한 strong reference 발생
        self?.doSomething()
    }
}
```

Nested closure에서 `[weak self]`를 사용한다면 가장 바깥 레벨의 closure에도 `[weak self]`를 추가해주어야 deinit이 정상적으로 됩니다. 안그러면 바인딩했던게 dispose가 안되네요.
